### PR TITLE
ANDROID-27 компонент HideQuestion + StaticPreview

### DIFF
--- a/core/ui/src/main/java/ru/yeahub/core_ui/component/HideQuestion.kt
+++ b/core/ui/src/main/java/ru/yeahub/core_ui/component/HideQuestion.kt
@@ -24,16 +24,6 @@ import ru.yeahub.core_ui.theme.LocalAppTypography
 import ru.yeahub.ui.R
 
 
-@StaticPreview
-@Composable
-fun HideQuestionPreview() {
-    HideQuestion(
-        text = "Что такое Virtual DOM, и как он работает?",
-        onClick = {}
-    )
-}
-
-
 @Composable
 fun HideQuestion(
     text: String,
@@ -85,3 +75,13 @@ fun HideQuestion(
         }
     }
 }
+
+@StaticPreview
+@Composable
+fun HideQuestionPreview() {
+    HideQuestion(
+        text = "Что такое Virtual DOM, и как он работает?",
+        onClick = {}
+    )
+}
+

--- a/core/ui/src/main/java/ru/yeahub/core_ui/component/HideQuestion.kt
+++ b/core/ui/src/main/java/ru/yeahub/core_ui/component/HideQuestion.kt
@@ -1,0 +1,87 @@
+package ru.yeahub.core_ui.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import ru.yeahub.core_ui.example.staticPreview.StaticPreview
+import ru.yeahub.core_ui.theme.LocalAppColors
+import ru.yeahub.core_ui.theme.LocalAppTypography
+import ru.yeahub.ui.R
+
+
+@StaticPreview
+@Composable
+fun HideQuestionPreview() {
+    HideQuestion(
+        text = "Что такое Virtual DOM, и как он работает?",
+        onClick = {}
+    )
+}
+
+
+@Composable
+fun HideQuestion(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+
+    Surface(
+        modifier = modifier
+            .padding(10.dp)
+            .fillMaxWidth(),
+        color = LocalAppColors.current.white900,
+        shape = RoundedCornerShape(8.dp),
+        shadowElevation = 2.dp,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+                .clickable {
+                    onClick()
+                }
+        ) {
+            Image(
+                painter = painterResource(R.drawable.ellipse), contentDescription = null,
+                modifier = Modifier
+                    .padding(top = 7.dp)
+            )
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            Text(
+                text = text,
+                modifier = Modifier.weight(1f),
+                style = LocalAppTypography.current.body3Accent.copy(lineHeight = 20.sp)
+            )
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            Box(
+                modifier = Modifier.size(24.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Image(
+                    painter = painterResource(R.drawable.arrow_vector),
+                    contentDescription = null,
+                )
+            }
+        }
+    }
+}

--- a/core/ui/src/main/java/ru/yeahub/core_ui/example/dynamicPreview/MyViewModel.kt
+++ b/core/ui/src/main/java/ru/yeahub/core_ui/example/dynamicPreview/MyViewModel.kt
@@ -1,4 +1,4 @@
-package ru.yeahub.example.dynamicPreview
+package ru.yeahub.core_ui.example.dynamicPreview
 
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableIntStateOf

--- a/core/ui/src/main/java/ru/yeahub/core_ui/example/dynamicPreview/PreviewExample.kt
+++ b/core/ui/src/main/java/ru/yeahub/core_ui/example/dynamicPreview/PreviewExample.kt
@@ -1,4 +1,4 @@
-package ru.yeahub.example.dynamicPreview
+package ru.yeahub.core_ui.example.dynamicPreview
 
 import android.annotation.SuppressLint
 import androidx.compose.foundation.layout.Arrangement

--- a/core/ui/src/main/java/ru/yeahub/core_ui/example/dynamicPreview/StandardScreenSizePreview.kt
+++ b/core/ui/src/main/java/ru/yeahub/core_ui/example/dynamicPreview/StandardScreenSizePreview.kt
@@ -1,4 +1,4 @@
-package ru.yeahub.example.dynamicPreview
+package ru.yeahub.core_ui.example.dynamicPreview
 
 import androidx.compose.ui.tooling.preview.Preview
 

--- a/core/ui/src/main/java/ru/yeahub/core_ui/example/staticPreview/PreviewExample.kt
+++ b/core/ui/src/main/java/ru/yeahub/core_ui/example/staticPreview/PreviewExample.kt
@@ -1,4 +1,4 @@
-package ru.yeahub.example.staticPreview
+package ru.yeahub.core_ui.example.staticPreview
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer

--- a/core/ui/src/main/java/ru/yeahub/core_ui/example/staticPreview/StaticPreview.kt
+++ b/core/ui/src/main/java/ru/yeahub/core_ui/example/staticPreview/StaticPreview.kt
@@ -1,4 +1,4 @@
-package ru.yeahub.example.staticPreview
+package ru.yeahub.core_ui.example.staticPreview
 
 import android.content.res.Configuration
 import androidx.compose.ui.tooling.preview.Preview

--- a/core/ui/src/main/res/drawable/arrow_vector.xml
+++ b/core/ui/src/main/res/drawable/arrow_vector.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="14dp"
+    android:height="8dp"
+    android:viewportWidth="14"
+    android:viewportHeight="8">
+  <path
+      android:pathData="M1,1L7,7L13,1"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.66667"
+      android:fillColor="#00000000"
+      android:strokeColor="#6A0BFF"
+      android:strokeLineCap="round"/>
+</vector>

--- a/core/ui/src/main/res/drawable/ellipse.xml
+++ b/core/ui/src/main/res/drawable/ellipse.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="5dp"
+    android:height="5dp"
+    android:viewportWidth="5"
+    android:viewportHeight="5">
+  <path
+      android:pathData="M2.5,2.5m-2.5,0a2.5,2.5 0,1 1,5 0a2.5,2.5 0,1 1,-5 0"
+      android:fillColor="#5533FF"/>
+</vector>


### PR DESCRIPTION
<img width="1057" alt="Screenshot 2025-06-24 at 01 10 43" src="https://github.com/user-attachments/assets/1c4d4fdb-385a-4ae0-be78-888edb0a84b0" />

Добавлен HideQuestion по дизайну [design hide question](https://www.figma.com/design/Oplq5dMeGs3oQxRG8NOBqD/YeaHub-%D0%94%D0%B8%D0%B7%D0%B0%D0%B9%D0%BD--%D0%A0%D1%83%D1%81%D0%BB%D0%B0%D0%BD-?node-id=17733-234310&t=IN6BPehp4KUPLh4h-4)
Статик превью для него, который перенесен из app модуля в coreUI



- Проблема со стилем для текста из Typography - его lineHeight = 130.sp, что делает огромный отступ если текст в 2 строки, как будто так быть не должно.
- Clickable зона как на сайте не у всего контейнера, а только у row с контентом, как будто можно изменить...

[задача-27](https://tracker.yandex.ru/ANDROID-27)