### PR TITLE
ANDROID-52: Верстка списка вопросов

### DIFF
--- a/feature/public-questions/api/src/main/AndroidManifest.xml
+++ b/feature/public-questions/api/src/main/AndroidManifest.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <application
-        android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
-        android:theme="@style/Theme.YeaHub" />
+
 
 </manifest>

--- a/feature/public-questions/impl/build.gradle.kts
+++ b/feature/public-questions/impl/build.gradle.kts
@@ -23,11 +23,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "17"
     }
     buildFeatures {
         compose = false

--- a/feature/public-questions/impl/build.gradle.kts
+++ b/feature/public-questions/impl/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
 
     // Timber
     implementation(libs.timber)
+    implementation(libs.androidx.ui.tooling.preview.android)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/feature/public-questions/impl/src/main/AndroidManifest.xml
+++ b/feature/public-questions/impl/src/main/AndroidManifest.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:allowBackup="true"
-        android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher_round"
-        android:supportsRtl="true"
-        android:theme="@style/Theme.YeaHub" />
+        android:supportsRtl="true" />
 
 </manifest>

--- a/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/domain/entity/QuestionModel.kt
+++ b/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/domain/entity/QuestionModel.kt
@@ -1,0 +1,10 @@
+package ru.yeahub.public_questions.impl.domain.entity
+
+data class QuestionModel(
+    val id: Long,
+    val title: String,
+    val rate: String?,
+    val complexity: String?,
+    val imageSc: String?,
+    val description: String,
+)

--- a/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/domain/entity/QuestionsModel.kt
+++ b/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/domain/entity/QuestionsModel.kt
@@ -1,10 +1,8 @@
 package ru.yeahub.public_questions.impl.domain.entity
 
 data class QuestionsModel(
-    val id: Long,
-    val title: String,
-    val rate: String?,
-    val complexity: String?,
-    val imageSc: String?,
-    val description: String,
+    val page: Long?,
+    val limit: Long?,
+    val data: List<QuestionModel>,
+    val total: Long
 )

--- a/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/domain/entity/QuestionsModel.kt
+++ b/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/domain/entity/QuestionsModel.kt
@@ -1,0 +1,10 @@
+package ru.yeahub.public_questions.impl.domain.entity
+
+data class QuestionsModel(
+    val id: Long,
+    val title: String,
+    val rate: String?,
+    val complexity: String?,
+    val imageSc: String?,
+    val description: String,
+)

--- a/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/command/HandleQuestionsCommand.kt
+++ b/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/command/HandleQuestionsCommand.kt
@@ -1,0 +1,33 @@
+package ru.yeahub.public_questions.impl.presentation.command
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.flowWithLifecycle
+import kotlinx.coroutines.flow.Flow
+
+@Composable
+fun HandleQuestionsCommand(
+    commandFlow: Flow<QuestionsScreenCommand>,
+    onNavigateToDetail: (id: String, title: String) -> Unit,
+    onBackClick: () -> Unit
+) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    LaunchedEffect(Unit) {
+        commandFlow
+            .flowWithLifecycle(lifecycleOwner.lifecycle, Lifecycle.State.STARTED)
+            .collect { command ->
+                when (command) {
+                    is QuestionsScreenCommand.OnMoreClick -> {
+                        onNavigateToDetail(command.id, command.title)
+                    }
+
+                    QuestionsScreenCommand.OnBackClick -> {
+                        onBackClick()
+                    }
+                }
+            }
+    }
+}

--- a/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/command/QuestionsScreenCommand.kt
+++ b/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/command/QuestionsScreenCommand.kt
@@ -1,0 +1,6 @@
+package ru.yeahub.public_questions.impl.presentation.command
+
+sealed class QuestionsScreenCommand {
+    data object OnBackClick : QuestionsScreenCommand()
+    data class OnMoreClick(val id: String, val title: String) : QuestionsScreenCommand()
+}

--- a/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/event/QuestionsScreenEvent.kt
+++ b/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/event/QuestionsScreenEvent.kt
@@ -1,0 +1,24 @@
+package ru.yeahub.public_questions.impl.presentation.event
+
+sealed class QuestionsScreenEvent {
+
+    /** Первичная загрузка */
+
+    data object LoadInitial : QuestionsScreenEvent()
+
+    /** Подгрузка следующей страницы */
+
+    data object LoadNextPage : QuestionsScreenEvent()
+
+    /** Обновление данных */
+
+    data object Refresh : QuestionsScreenEvent()
+
+    /** Клик по карточке вопроса(подробнее) */
+
+    data class OnMoreClick(val id: String, val title: String) : QuestionsScreenEvent()
+
+    /** Клик назад */
+
+    data object OnBackClick : QuestionsScreenEvent()
+}

--- a/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/mapper/DomainToPresentationMapper.kt
+++ b/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/mapper/DomainToPresentationMapper.kt
@@ -4,17 +4,17 @@ import ru.yeahub.public_questions.impl.domain.entity.QuestionsModel
 import ru.yeahub.public_questions.impl.presentation.screen.QuestionUiModel
 
 class DomainToPresentationMapper {
-    /**
-     * Обработка нулабельного состояния будет происходит в data слое. снизу - > это временное решение
-     */
-    fun domainQuestionsModelToUiModel(domainQuestionsModel: QuestionsModel): QuestionUiModel {
-        return QuestionUiModel(
-            id = domainQuestionsModel.id,
-            title = domainQuestionsModel.title,
-            rate = domainQuestionsModel.rate ?: "N/A",
-            complexity = domainQuestionsModel.complexity ?: "",
-            imageSc = domainQuestionsModel.imageSc ?: "",
-            description = domainQuestionsModel.description
-        )
+
+    fun domainQuestionsModelToUiModel(domainQuestionsModel: QuestionsModel): List<QuestionUiModel> {
+        return domainQuestionsModel.data.map { question ->
+            QuestionUiModel(
+                id = question.id,
+                title = question.title,
+                rate = question.rate.toString(),
+                complexity = question.complexity.toString(),
+                imageSc = question.imageSc.toString(),
+                description = question.description
+            )
+        }
     }
 }

--- a/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/mapper/DomainToPresentationMapper.kt
+++ b/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/mapper/DomainToPresentationMapper.kt
@@ -1,0 +1,20 @@
+package ru.yeahub.public_questions.impl.presentation.mapper
+
+import ru.yeahub.public_questions.impl.domain.entity.QuestionsModel
+import ru.yeahub.public_questions.impl.presentation.screen.QuestionUiModel
+
+class DomainToPresentationMapper {
+    /**
+     * Обработка нулабельного состояния будет происходит в data слое. снизу - > это временное решение
+     */
+    fun domainQuestionsModelToUiModel(domainQuestionsModel: QuestionsModel): QuestionUiModel {
+        return QuestionUiModel(
+            id = domainQuestionsModel.id,
+            title = domainQuestionsModel.title,
+            rate = domainQuestionsModel.rate ?: "N/A",
+            complexity = domainQuestionsModel.complexity ?: "",
+            imageSc = domainQuestionsModel.imageSc ?: "",
+            description = domainQuestionsModel.description
+        )
+    }
+}

--- a/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/screen/QuestionUiModel.kt
+++ b/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/screen/QuestionUiModel.kt
@@ -1,0 +1,10 @@
+package ru.yeahub.public_questions.impl.presentation.screen
+
+data class QuestionUiModel(
+    val id: Long,
+    val title: String,
+    val rate: String,
+    val complexity: String,
+    val imageSc: String,
+    val description: String
+)

--- a/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/screen/QuestionsScreenState.kt
+++ b/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/screen/QuestionsScreenState.kt
@@ -1,0 +1,17 @@
+package ru.yeahub.public_questions.impl.presentation.screen
+
+sealed class QuestionsScreenState() {
+    data object Initial : QuestionsScreenState()
+
+    data object Loading : QuestionsScreenState()
+
+    data class Loaded(
+        val questions: List<QuestionUiModel>,
+        val isEndReached: Boolean
+    ) : QuestionsScreenState()
+
+    data class Error(
+        val questions: List<QuestionUiModel>,
+        val throwable: Throwable
+    ) : QuestionsScreenState()
+}

--- a/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/viewmodel/QuestionsViewModel.kt
+++ b/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/viewmodel/QuestionsViewModel.kt
@@ -1,0 +1,37 @@
+package ru.yeahub.public_questions.impl.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import ru.yeahub.public_questions.impl.presentation.event.QuestionsScreenEvent
+
+class QuestionsViewModel : ViewModel() {
+
+    fun onEvent(event: QuestionsScreenEvent) {
+        when (event) {
+            is QuestionsScreenEvent.LoadInitial -> loadInitial()
+            is QuestionsScreenEvent.LoadNextPage -> loadNextPage()
+            is QuestionsScreenEvent.Refresh -> refresh()
+            is QuestionsScreenEvent.OnMoreClick -> onMoreClick(event.id, event.title)
+            is QuestionsScreenEvent.OnBackClick -> onBackClick()
+        }
+    }
+
+    private fun loadInitial() {
+        TODO()
+    }
+
+    private fun loadNextPage() {
+        TODO()
+    }
+
+    private fun refresh() {
+        TODO()
+    }
+
+    private fun onMoreClick(id: String, title: String) {
+        TODO()
+    }
+
+    private fun onBackClick() {
+        TODO()
+    }
+}

--- a/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/views/ErrorItem.kt
+++ b/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/views/ErrorItem.kt
@@ -19,7 +19,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
+import ru.yeahub.core_ui.example.staticPreview.StaticPreview
 import ru.yeahub.public_questions.impl.R
 
 @Composable
@@ -66,4 +69,21 @@ fun ErrorItem(error: Throwable, onRetry: () -> Unit) {
             Text(stringResource(R.string.try_again))
         }
     }
+}
+
+@StaticPreview
+@Composable
+fun ShowErrorItemPreview(
+    @PreviewParameter(ErrorStateProvider::class) error: Throwable
+) {
+    ErrorItem(error = error, onRetry = {})
+}
+
+class ErrorStateProvider : PreviewParameterProvider<Throwable> {
+    override val values = sequenceOf(
+        Throwable("Network Error"),
+        Throwable("Timeout Error"),
+        Throwable("Server Error"),
+        Throwable("Unknown Error")
+    )
 }

--- a/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/views/LoadingPlaceholderItem.kt
+++ b/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/views/LoadingPlaceholderItem.kt
@@ -5,11 +5,13 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -22,6 +24,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.valentinilk.shimmer.shimmer
+import ru.yeahub.core_ui.example.staticPreview.StaticPreview
 import ru.yeahub.ui.R
 
 @Composable
@@ -61,7 +64,9 @@ fun PlaceholderItem() {
             Spacer(modifier = Modifier.width(8.dp))
 
             Box(
-                modifier = Modifier.size(24.dp).background(Color.LightGray),
+                modifier = Modifier
+                    .size(24.dp)
+                    .background(Color.LightGray),
                 contentAlignment = Alignment.Center,
             ) {
                 Image(
@@ -73,3 +78,25 @@ fun PlaceholderItem() {
         }
     }
 }
+
+@StaticPreview
+@Composable
+fun PlaceholderItemPreview() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(
+                top = 20.dp,
+                bottom = 20.dp,
+                start = 10.dp,
+                end = 10.dp
+            )
+    ) {
+        LazyColumn {
+            items(TEST) {
+                PlaceholderItem()
+            }
+        }
+    }
+}
+private const val TEST = 6

--- a/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/views/QuestionsItem.kt
+++ b/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/views/QuestionsItem.kt
@@ -168,7 +168,7 @@ class MockQuestionsViewModel : ViewModel() {
                 title = "Mocked Question Title $index",
                 rate = "Rate: ${index * 3}",
                 complexity = "Complexity: ${index + 1}",
-                imageSc = "https://via.placeholder.com/150",
+                imageSc = "https://images.dog.ceo/breeds/terrier-welsh/lucy.jpg",
                 description = "Mocked description for question #$index"
             )
         }

--- a/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/views/QuestionsItem.kt
+++ b/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/views/QuestionsItem.kt
@@ -3,44 +3,71 @@ package ru.yeahub.public_questions.impl.presentation.views
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import ru.yeahub.core_ui.component.HideQuestion
+import ru.yeahub.core_ui.example.dynamicPreview.StandardScreenSizePreview
+import ru.yeahub.core_ui.example.staticPreview.StaticPreview
+import ru.yeahub.public_questions.impl.presentation.screen.QuestionUiModel
 
 @Composable
 fun QuestionsItem(
+    questions: List<QuestionUiModel>,
     onClickMore: (itemId: String, title: String) -> Unit,
     onBackClick: () -> Unit
 ) {
-    var isExtended by remember { mutableStateOf(false) }
+    val extendedStates = remember {
+        mutableStateOf(
+            value = mutableMapOf<Long, Boolean>()
+                .apply {
+                    questions.forEach { this[it.id] = false }
+                }
+        )
+    }
+
+    fun toggleExtendedState(id: Long) {
+        val currentState = extendedStates.value
+        extendedStates.value = currentState.toMutableMap().apply {
+            this[id] = !(this[id] ?: false)
+        }
+    }
     Card(
         modifier = Modifier.padding(
             top = FIGMA_PADDING_TOP.dp,
             bottom = FIGMA_PADDING_BOTTOM.dp,
             start = FIGMA_PADDING_START.dp,
             end = FIGMA_PADDING_END.dp
-        )
+        ),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
     ) {
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize(),
         ) {
-            items(count = 12) { question ->
+            items(questions, key = { it.id }) { question ->
+                val isExtended = extendedStates.value[question.id] ?: false
                 HideQuestion(
-                    questionText = "Что такое Virtual DOM, и как он работает?",
-                    ratingValue = "10",
-                    difficultyValue = "5",
-                    answerText = "Никак не работает",
-                    imageUrl = "",
+                    questionText = question.title,
+                    ratingValue = question.rate,
+                    difficultyValue = question.complexity,
+                    answerText = question.description,
+                    imageUrl = question.imageSc,
                     isExtended = isExtended,
-                    onClickMore = {},
-                    onToggle = { isExtended = !isExtended },
+                    onClickMore = { onClickMore(question.id.toString(), question.title) },
+                    onToggle = { toggleExtendedState(question.id) },
                     modifier = Modifier
                 )
             }
@@ -48,7 +75,117 @@ fun QuestionsItem(
     }
 }
 
+/**
+ * Static preview
+ */
+@StaticPreview
+@Composable
+fun QuestionsItemPreview() {
+    val mockQuestions = listOf(
+        QuestionUiModel(
+            id = 1,
+            title = "Что такое Virtual DOM?",
+            rate = "5",
+            complexity = "Средняя",
+            imageSc = "ic_virtual_dom",
+            description = "Это концепция, используемая в React для оптимизации рендеринга."
+        ),
+        QuestionUiModel(
+            id = 2,
+            title = "Что такое Redux?",
+            rate = "",
+            complexity = "Высокая",
+            imageSc = "",
+            description = "Менеджер состояния для JavaScript-приложений."
+        ),
+        QuestionUiModel(
+            id = 3,
+            title = "Что такое Kotlin?",
+            rate = "10",
+            complexity = "Низкая",
+            imageSc = "",
+            description = "Современный язык программирования для JVM, совместимый с Java."
+        ),
+        QuestionUiModel(
+            id = 4,
+            title = "Что такое TypeScript?",
+            rate = "",
+            complexity = "Средняя",
+            imageSc = "",
+            description = "Это надмножество JavaScript с типизацией."
+        ),
+        QuestionUiModel(
+            id = 5,
+            title = "Что такое функциональное программирование?",
+            rate = "10",
+            complexity = "Очень высокая",
+            imageSc = "ic_functional_programming",
+            description = "Это парадигма программирования," +
+                    " где функции являются основными строительными блоками."
+        ),
+        QuestionUiModel(
+            id = 6,
+            title = "Что такое Monads в функциональном программировании?",
+            rate = "8",
+            complexity = "Очень высокая",
+            imageSc = "",
+            description = "Это концепция, которая помогает управлять побочными эффектами" +
+                    " в функциональном программировании."
+        ),
+        QuestionUiModel(
+            id = 7,
+            title = "Что такое Java?",
+            rate = "7",
+            complexity = "Средняя",
+            imageSc = "ic_java",
+            description = "Это язык программирвания"
+        )
+    )
+
+    QuestionsItem(
+        questions = mockQuestions,
+        onClickMore = { itemId, title -> },
+        onBackClick = {}
+    )
+}
+
 private const val FIGMA_PADDING_BOTTOM = 20
 private const val FIGMA_PADDING_TOP = 20
 private const val FIGMA_PADDING_START = 10
 private const val FIGMA_PADDING_END = 10
+
+/**
+ * Dinamic preview
+ */
+class MockQuestionsViewModel : ViewModel() {
+    private val _state = MutableStateFlow<List<QuestionUiModel>>(emptyList())
+    val state: Flow<List<QuestionUiModel>> get() = _state.asStateFlow()
+
+    init {
+        _state.value = List(TEST) { index ->
+            QuestionUiModel(
+                id = index.toLong(),
+                title = "Mocked Question Title $index",
+                rate = "Rate: ${index * 3}",
+                complexity = "Complexity: ${index + 1}",
+                imageSc = "https://via.placeholder.com/150",
+                description = "Mocked description for question #$index"
+            )
+        }
+    }
+}
+
+private const val TEST = 10
+
+@StandardScreenSizePreview
+@Composable
+fun PreviewQuestionsScreen() {
+    val viewModel: MockQuestionsViewModel = viewModel()
+    val state = viewModel.state.collectAsState(emptyList())
+
+    QuestionsItem(
+        questions = state.value,
+        onClickMore = { id, title -> },
+        onBackClick = {}
+    )
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ jetbrainsCompose = "1.6.0"
 coil = "2.5.0"
 jsoup = "1.17.2"
 shimmer = "1.3.3"
+uiToolingPreviewAndroid = "1.8.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -78,6 +79,7 @@ junit = { group = "junit", name = "junit", version.ref = "junitVersion" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxJunit" }
 androidx-runtime-android = { group = "androidx.compose.runtime", name = "runtime-android", version.ref = "runtimeAndroid" }
 compose-shimmer = { group = "com.valentinilk.shimmer", name = "compose-shimmer", version.ref = "shimmer" }
+androidx-ui-tooling-preview-android = { group = "androidx.compose.ui", name = "ui-tooling-preview-android", version.ref = "uiToolingPreviewAndroid" }
 
 [plugins]
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }


### PR DESCRIPTION
1) Добавлено динамическое/статическое preview для view элементов.
2) Добавлен QuestionsUIModel(Модель данных UI слоя) и состояние экрана.
3) Добавлена заготовка QuestionsViewModel и мапер domainToPresentation.
4) Добавлены event/command и composable функция к ней.

Затронутые модули: feature/public-questions/impl

Цель задачи: Сверстать необходимые сущности для добавления сетевого слоя и написания логики
<img width="579" height="649" alt="Снимок экрана 2025-07-28 094857" src="https://github.com/user-attachments/assets/fda2ab11-948f-420b-9cdd-cadc5bcee5db" />
<img width="705" height="537" alt="Снимок экрана 2025-07-28 094902" src="https://github.com/user-attachments/assets/dd399a8f-100c-48b7-898c-000fce6f4068" />
<img width="320" height="696" alt="Снимок экрана 2025-07-28 094926" src="https://github.com/user-attachments/assets/d9899611-4dd2-4e6c-9563-ad63a5f479d7" />
<img width="777" height="474" alt="Снимок экрана 2025-07-28 094930" src="https://github.com/user-attachments/assets/ffce28a7-476c-4dec-a322-aeb2f243269b" />
<img width="774" height="599" alt="Снимок экрана 2025-07-28 094626" src="https://github.com/user-attachments/assets/066f1573-ed25-43f7-8275-95c6376ad948" />
<img width="334" height="654" alt="Снимок экрана 2025-07-28 094619" src="https://github.com/user-attachments/assets/dca0a788-e956-4161-a9cf-591efb66fd9a" />

https://github.com/user-attachments/assets/9f32f868-c626-4e64-a314-5e2dc5c3dfb4

