### PR TITLE
Android 101: Перенос списка вопросов на tab с вопросами. 

### DIFF
--- a/core/navigation-impl/src/main/java/ru/yeahub/navigation_impl/model/BottomNavigationItem.kt
+++ b/core/navigation-impl/src/main/java/ru/yeahub/navigation_impl/model/BottomNavigationItem.kt
@@ -45,7 +45,7 @@ sealed class BottomNavigationItem(
     )
 
     data object Questions : BottomNavigationItem(
-        route = FeatureRoute.QuestionsFeature.FEATURE_NAME,
+        route = FeatureRoute.PublicQuestionsFeature.FEATURE_NAME + "/" + "All",
         label = "Вопросы",
         icon =  R.drawable.icon_tab_collections
     )

--- a/core/network-impl/src/main/java/ru/yeahub/network_impl/NetworkModule.kt
+++ b/core/network-impl/src/main/java/ru/yeahub/network_impl/NetworkModule.kt
@@ -1,15 +1,25 @@
 package ru.yeahub.network_impl
 
+import android.annotation.SuppressLint
+import okhttp3.OkHttpClient
 import org.koin.dsl.module
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import ru.yeahub.network_api.ApiService
 import ru.yeahub.network_api.NetworkProvider
+import java.security.cert.X509Certificate
+import javax.net.ssl.SSLContext
+import javax.net.ssl.TrustManager
+import javax.net.ssl.X509TrustManager
+
+var a: String? = null
+var b: String? = null
 
 val networkModule = module {
     single<Retrofit> {
         Retrofit.Builder()
             .baseUrl("https://api.yeatwork.ru")
+            .client(getUnsafeOkHttpClient())
             .addConverterFactory(GsonConverterFactory.create())
             .build()
     }
@@ -27,4 +37,30 @@ val networkModule = module {
             override val apiService: ApiService = get()
         }
     }
+}
+
+fun getUnsafeOkHttpClient(): OkHttpClient {
+    val trustAllCerts = arrayOf<TrustManager>(object : X509TrustManager {
+
+        @SuppressLint("TrustAllX509TrustManager")
+        override fun checkClientTrusted(chain: Array<X509Certificate>, authType: String) {
+            val certificate = chain[0]
+            a = certificate.toString()
+        }
+
+        @SuppressLint("TrustAllX509TrustManager")
+        override fun checkServerTrusted(chain: Array<X509Certificate>, authType: String) {
+            val certificate = chain[0]
+            b = certificate.toString()
+        }
+
+        override fun getAcceptedIssuers(): Array<X509Certificate> = arrayOf()
+    })
+    val sslContext = SSLContext.getInstance("SSL")
+    sslContext.init(null, trustAllCerts, java.security.SecureRandom())
+
+    return OkHttpClient.Builder()
+        .sslSocketFactory(sslContext.socketFactory, trustAllCerts[0] as X509TrustManager)
+        .hostnameVerifier { _, _ -> true }
+        .build()
 }

--- a/core/ui/src/main/java/ru/yeahub/core_ui/component/HideQuestion.kt
+++ b/core/ui/src/main/java/ru/yeahub/core_ui/component/HideQuestion.kt
@@ -71,7 +71,7 @@ fun HideQuestion(
                     .fillMaxWidth()
                     .clickable {
                         println("Click! isExtended before: $isExtended")
-                        onToggle()
+                        onClickMore()
                     },
             ) {
                 Image(

--- a/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/PublicQuestionsFeatureImpl.kt
+++ b/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/PublicQuestionsFeatureImpl.kt
@@ -11,12 +11,13 @@ import ru.yeahub.navigation_api.FeatureRoute
 import ru.yeahub.navigation_api.NavigationPathManager
 import ru.yeahub.public_questions.impl.presentation.intents.PublicQuestionsResult
 import ru.yeahub.public_questions.impl.presentation.screen.PublicQuestionsScreen
+import timber.log.Timber
 
 class PublicQuestionsFeatureImpl : FeatureApi {
     override fun getFeatureName(): String = FeatureRoute.PublicQuestionsFeature.FEATURE_NAME
 
     override fun isRootFeature(): Boolean {
-        return false
+        return true
     }
 
     override fun registerGraph(
@@ -27,25 +28,15 @@ class PublicQuestionsFeatureImpl : FeatureApi {
     ) {
         val featurePath = pathManager.createParametrizedPath(
             getFeatureName(),
-            SKILL_FILTER,
-            SKILLS,
-            HEADING
+            SKILL_FILTER
         )
 
         navGraphBuilder.composable(
             route = featurePath,
             arguments = listOf(
-                navArgument(SKILL_FILTER) { type = NavType.StringType },
-                navArgument(SKILLS) { type = NavType.StringType },
-                navArgument(HEADING) { type = NavType.StringType }
+                navArgument(SKILL_FILTER) { type = NavType.StringType }
             )
         ) { backStackEntry ->
-            val heading = backStackEntry
-                .arguments
-                ?.getString(HEADING) ?: ""
-            val skills = backStackEntry.arguments
-                ?.getString(SKILLS)
-                ?.split(",") ?: listOf()
             val skillFilter = backStackEntry
                 .arguments
                 ?.getString(SKILL_FILTER) ?: ""
@@ -58,17 +49,17 @@ class PublicQuestionsFeatureImpl : FeatureApi {
                         )
 
                         is PublicQuestionsResult.NavigateToDetail -> {
-                            val detailPath = pathManager.createParametrizedPath(
-                                FeatureRoute.DetailsFeature.FEATURE_NAME,
-                                result.id
-                            )
-                            navController.navigate(detailPath)
+                            val detailRout =
+                                getFeatureName() + "/" + FeatureRoute.DetailQuestionFeature
+                                    .FEATURE_NAME + "/" + result.id
+                            Timber.tag("Test")
+                                .d("PublicQuestionsFeatureImpl registerGraph: $detailRout")
+                            navController.navigate(detailRout)
                         }
                     }
                 },
-                skills = skills,
                 skillFilter = skillFilter,
-                heading = heading
+                heading = skillFilter
             )
         }
     }
@@ -94,5 +85,3 @@ class PublicQuestionsFeatureImpl : FeatureApi {
 }
 
 private const val SKILL_FILTER = "skillFilter"
-private const val SKILLS = "skills"
-private const val HEADING = "skills"

--- a/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/mapper/PublicQuestionDomainToPresentationMapper.kt
+++ b/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/mapper/PublicQuestionDomainToPresentationMapper.kt
@@ -9,7 +9,7 @@ class PublicQuestionDomainToPresentationMapper {
         publicQuestionModel: PublicQuestionModel
     ): PublicQuestionUiModel {
         return PublicQuestionUiModel(
-            id = publicQuestionModel.id,
+            id = publicQuestionModel.id.toString(),
             title = publicQuestionModel.title
         )
     }

--- a/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/screen/PublicQuestionUiModel.kt
+++ b/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/screen/PublicQuestionUiModel.kt
@@ -1,6 +1,6 @@
 package ru.yeahub.public_questions.impl.presentation.screen
 
 data class PublicQuestionUiModel(
-    val id: Long,
+    val id: String,
     val title: String,
 )

--- a/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/screen/PublicQuestionsScreen.kt
+++ b/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/screen/PublicQuestionsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -117,9 +118,9 @@ fun PublicQuestionsScreen(
                 onBackClick = { viewModel.onEvent(PublicQuestionsScreenEvent.OnBackClick) }
             )
         }
-    ) { innerPadding ->
+    ) { padding ->
         PublicQuestionsContent(
-            modifier = Modifier.padding(innerPadding),
+            padding = padding,
             screenState = screenState,
             listState = lazyListState,
             onRetryLoadInitial = { viewModel.onEvent(PublicQuestionsScreenEvent.LoadInitial) },
@@ -209,6 +210,7 @@ fun TopAppBarWithBottomBorder(
 @Composable
 private fun PublicQuestionsContent(
     modifier: Modifier = Modifier,
+    padding: PaddingValues,
     title: String,
     onMoreCLick: (id: String) -> Unit,
     screenState: PublicQuestionsScreenState,
@@ -234,6 +236,7 @@ private fun PublicQuestionsContent(
                     )
                 } else {
                     QuestionsListWithFooter(
+                        padding = padding,
                         listState = listState,
                         questions = screenState.questions,
                         isEndReached = true,
@@ -253,6 +256,7 @@ private fun PublicQuestionsContent(
                     EmptyState()
                 } else {
                     QuestionsListWithFooter(
+                        padding = padding,
                         listState = listState,
                         questions = screenState.questions,
                         isEndReached = screenState.isEndReached,
@@ -313,6 +317,7 @@ private fun FullScreenError(
 
 @Composable
 private fun QuestionsListWithFooter(
+    padding: PaddingValues,
     nameQuestion: String,
     listState: LazyListState,
     questions: List<PublicQuestionUiModel>,
@@ -324,7 +329,7 @@ private fun QuestionsListWithFooter(
 ) {
     LazyColumn(
         state = listState,
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier.fillMaxSize().padding(padding)
     ) {
         item {
             Box(modifier = Modifier.padding(start = 15.dp, bottom = 20.dp, top = 20.dp)) {

--- a/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/views/PublicQuestionsItem.kt
+++ b/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/views/PublicQuestionsItem.kt
@@ -40,13 +40,13 @@ fun PublicQuestionsItem(
 @Composable
 fun QuestionsItemPreview() {
     val mockQuestions = listOf(
-        PublicQuestionUiModel(id = 1, title = "Что такое Virtual DOM?"),
-        PublicQuestionUiModel(id = 2, title = "Что такое Redux?"),
-        PublicQuestionUiModel(id = 3, title = "Что такое Kotlin?"),
-        PublicQuestionUiModel(id = 4, title = "Что такое TypeScript?"),
-        PublicQuestionUiModel(id = 5, title = "Что такое функциональное программирование?"),
-        PublicQuestionUiModel(id = 6, title = "Что такое Monads в функциональном программировании?"),
-        PublicQuestionUiModel(id = 7, title = "Что такое Java?")
+        PublicQuestionUiModel(id = "1", title = "Что такое Virtual DOM?"),
+        PublicQuestionUiModel(id = "2", title = "Что такое Redux?"),
+        PublicQuestionUiModel(id = "3", title = "Что такое Kotlin?"),
+        PublicQuestionUiModel(id = "4", title = "Что такое TypeScript?"),
+        PublicQuestionUiModel(id = "5", title = "Что такое функциональное программирование?"),
+        PublicQuestionUiModel(id = "6", title = "Что такое Monads в функциональном программировании?"),
+        PublicQuestionUiModel(id = "7", title = "Что такое Java?")
     )
     LazyColumn {
         items(mockQuestions) { question ->
@@ -68,7 +68,7 @@ class MockQuestionsViewModel : ViewModel() {
     init {
         _state.value = List(TEST) { index ->
             PublicQuestionUiModel(
-                id = index.toLong(),
+                id = index.toString(),
                 title = "Mocked Question Title $index",
             )
         }


### PR DESCRIPTION
1) В BottomNavigationItem изменен путь для перехода на PublicQuestionsScreen
2) В NetWorkModule добавлен client для мока данных
3) В HideQuestions добавлен клик
4) В PublicQuestionUiModel Long заменен на String

Затронутые модули: 
core/network-Impl
core/ui
feature/public-qestions/impl
Цель задачи:
1) Иметь возможность мокать данные.
2) Заменить tab "Вопросы" на  экран PublicQuestionsScreen
