### PR TITLE
ANDR-11: Навигация по разделам и ошибки

### DIFF
--- a/core/ui/src/main/java/ru/yeahub/core_ui/component/CollectionsOrQuestionContent.kt
+++ b/core/ui/src/main/java/ru/yeahub/core_ui/component/CollectionsOrQuestionContent.kt
@@ -9,7 +9,9 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -34,11 +36,12 @@ fun CollectionsOrQuestionContent(
     onClick: () -> Unit,
 ) {
     val context = LocalContext.current
-
+    val scrollState = rememberScrollState()
     Column(
         modifier = Modifier
             .fillMaxSize()
             .padding(start = 16.dp, top = 24.dp, end = 16.dp, bottom = 24.dp)
+            .verticalScroll(scrollState)
     ) {
         Text(
             text = state.title.getString(context),

--- a/feature/example-home/impl/src/main/java/ru/yeahub/example_home/impl/presentation/view/QuestionsMainScreen.kt
+++ b/feature/example-home/impl/src/main/java/ru/yeahub/example_home/impl/presentation/view/QuestionsMainScreen.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -61,7 +63,7 @@ fun QuestionsMainScreenContent(
     onBackClick: () -> Unit
 ) {
     val context = LocalContext.current
-
+    val scrollState = rememberScrollState()
     when (state) {
         is QuestionMainScreenState.Loading -> {
             Box(
@@ -89,6 +91,7 @@ fun QuestionsMainScreenContent(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(top = 24.dp)
+                    .verticalScroll(scrollState)
             ) {
                 //Заголовок
                 Text(


### PR DESCRIPTION
исправил баг с невозможностью скрола на экранах главного меню, коллекций и вопросов

**Затронутые модули:**
core/ui
feature/example-home

**Цель задачи:**
исправить горизонтальную навигацию