### PR TITLE
ANDR 16: Исправление бага - Верстка страницы специализаций

### DIFF
--- a/feature/selection-specializations/impl/src/main/java/ru/yeahub/selection_specializations/impl/CollectionSpecializationsFeatureImpl.kt
+++ b/feature/selection-specializations/impl/src/main/java/ru/yeahub/selection_specializations/impl/CollectionSpecializationsFeatureImpl.kt
@@ -25,7 +25,7 @@ class CollectionSpecializationsFeatureImpl() : FeatureApi {
         pathManager: NavigationPathManager,
     ) {
         SpecializationScreen(
-            headerText = TextOrResource.Resource(R.string.selection_specializations_list_header),
+            headerText = TextOrResource.Resource(R.string.selection_specializations_top_bar_header),
             onResult = { result ->
                 when (result) {
                     SpecializationsScreenResult.NavigateBack -> {

--- a/feature/selection-specializations/impl/src/main/java/ru/yeahub/selection_specializations/impl/QuestionSpecializationsFeatureImpl.kt
+++ b/feature/selection-specializations/impl/src/main/java/ru/yeahub/selection_specializations/impl/QuestionSpecializationsFeatureImpl.kt
@@ -26,7 +26,7 @@ class QuestionSpecializationsFeatureImpl() : FeatureApi {
         pathManager: NavigationPathManager,
     ) {
         SpecializationScreen(
-            headerText = TextOrResource.Resource(R.string.selection_specializations_list_header),
+            headerText = TextOrResource.Resource(R.string.selection_specializations_top_bar_header),
             onResult = { result ->
                 when (result) {
                     SpecializationsScreenResult.NavigateBack -> {

--- a/feature/selection-specializations/impl/src/main/java/ru/yeahub/selection_specializations/impl/ui/SpecializationScreen.kt
+++ b/feature/selection-specializations/impl/src/main/java/ru/yeahub/selection_specializations/impl/ui/SpecializationScreen.kt
@@ -67,7 +67,7 @@ val CUSTOM_SHIMMER_HEIGHT = 16.dp
 
 @Composable
 fun SpecializationScreen(
-    headerText: TextOrResource = TextOrResource.Resource(R.string.selection_specializations_list_header),
+    headerText: TextOrResource = TextOrResource.Resource(R.string.selection_specializations_top_bar_header),
     onResult: (SpecializationsScreenResult) -> Unit
 ) {
     val specializationViewModel: SpecializationViewModel = koinViewModel()
@@ -220,7 +220,7 @@ fun ScreenUI(
                         SpecializationsLoadingScreen(padding = padding)
                     } else {
                         BaseSpecializationsScreen(
-                            headerText = headerText,
+                            headerText = TextOrResource.Resource(R.string.selection_specializations_list_header_text),
                             onItemClick = { id, title ->
                                 onSpecialEvent(
                                     SpecializationScreenEvent.OnSpecialClick(
@@ -244,10 +244,14 @@ fun ScreenUI(
                     ErrorScreen(
                         error = screenState.throwable.message
                             ?: defaultErrorText.getString(context),
-                        errorText = TextOrResource.Text("Something went wrong..."),
-                        titleText = TextOrResource.Text("Crash"),
-                        backText = TextOrResource.Text("Back"),
-                        unknownErrorText = TextOrResource.Text("Loading data failed"),
+                        errorText = TextOrResource
+                            .Resource(R.string.selection_specializations_error_message),
+                        titleText = TextOrResource
+                            .Resource(R.string.selection_specializations_error_title),
+                        backText = TextOrResource
+                            .Resource(R.string.selection_specializations_error_back_button),
+                        unknownErrorText = TextOrResource
+                            .Resource(R.string.selection_specializations_unknown_error_text),
                         onBack = { onSpecialEvent(SpecializationScreenEvent.OnBackClick) }
                     )
                 }
@@ -332,7 +336,7 @@ fun SpecializationsScreenPreview(
     @PreviewParameter(ListSpecializationScreenProvider::class) params: SpecializationScreenParams
 ) {
     ScreenUI(
-        headerText = TextOrResource.Resource(R.string.selection_specializations_list_header),
+        headerText = TextOrResource.Resource(R.string.selection_specializations_top_bar_header),
         screenState = params.screenState,
         onSpecialEvent = { _ -> Timber.tag("Preview").d("pressed item") },
         listState = rememberLazyListState()

--- a/feature/selection-specializations/impl/src/main/res/values/strings.xml
+++ b/feature/selection-specializations/impl/src/main/res/values/strings.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="selection_specializations_list_header">IT Specilializations</string>
-    <string name="selection_specialization_loading_specializations">Loading specializations...</string>
-    <string name="selection_specializations_header_text">Specializations</string>
-    <string name="selection_specializations_top_bar_title">Selection specializations</string>
+    <string name="selection_specializations_top_bar_header">Выбор специальности</string>
+    <string name="selection_specialization_loading_specializations">Загрузка специальностей...</string>
+    <string name="selection_specializations_list_header_text">IT-специальность</string>
+    <string name="selection_specializations_error_message">Что-то пошло не так...</string>
+    <string name="selection_specializations_error_title">Ошибка</string>
+    <string name="selection_specializations_error_back_button">Назад</string>
+    <string name="selection_specializations_unknown_error_text">Ошибка загрузки данных</string>
 </resources>


### PR DESCRIPTION
В соответствии с  замечаниями (https://tracker.yandex.ru/ajax/v2/attachments/1586?inline=true) изменены названия на странице специализаций. 
<img width="746" height="1674" alt="image" src="https://github.com/user-attachments/assets/d70187fe-b7af-482c-8d89-dca31feade7c" />

Так же изменены названия на странице с ошибкой
<img width="746" height="1674" alt="image" src="https://github.com/user-attachments/assets/5ce19619-bb20-4d5b-9f30-f1234baf3fca" />
