### PR TITLE
ANDR-20: Добавил нижний отступ после последнего элемента в «Вопросы» и «Коллекции»

### DIFF
--- a/feature/selection-specializations/impl/src/main/java/ru/yeahub/selection_specializations/impl/ui/SpecializationScreen.kt
+++ b/feature/selection-specializations/impl/src/main/java/ru/yeahub/selection_specializations/impl/ui/SpecializationScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -168,6 +169,9 @@ fun BaseSpecializationsScreen(
                         )
                     }
                 )
+            }
+            item {
+                Spacer(modifier = Modifier.height(4.dp))
             }
         }
 


### PR DESCRIPTION
🧩 Что сделано:
•	Добавлен нижний отступ после последнего элемента списка.
•	В конец LazyColumn вставлен item { Spacer(...) }.
•	Исправлено расположение последнего элемента, чтобы он не прилегал к нижней границе экрана.
•	Изменения внесены в функцию BaseSpecializationsScreen.
🗂 Затронутые модули:
•	feature -> selection-specializations-impl
🎯 Цель задачи:
•	Добиться корректной работы скролла: чтобы пролистывание доходило до конца списка, и все формы специализаций отображались полностью, включая нижнюю тень и границы элементов.
•	Ранее скролл обрезал последний элемент («проверка9»), и визуально он отображался неправильно.
было : 
<img width="633" height="1280" alt="изображение_2025-11-21_104246333" src="https://github.com/user-attachments/assets/f1a4d5b0-78bc-4686-bc7e-1108dfa050b6" />
 теперь: 
<img width="1080" height="2160" alt="Screenshot_20251121_104323" src="https://github.com/user-attachments/assets/2e7858d6-0f41-49e2-8504-d86e5128afeb" />


