### PR TITLE
ANDR-24 Навешена кликабельность на всю вьюшку вопроса/коллекции

### DIFF
--- a/core/ui/src/main/java/ru/yeahub/core_ui/component/HideQuestion.kt
+++ b/core/ui/src/main/java/ru/yeahub/core_ui/component/HideQuestion.kt
@@ -56,7 +56,11 @@ fun HideQuestion(
     Surface(
         modifier = modifier
             .padding(10.dp)
-            .fillMaxWidth(),
+            .fillMaxWidth()
+            .clickable {
+                println("Click! isExtended before: $isExtended")
+                onClickMore()
+            },
         color = Theme.colors.white900,
         shape = RoundedCornerShape(8.dp),
         shadowElevation = 2.dp,
@@ -68,11 +72,7 @@ fun HideQuestion(
         ) {
             Row(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable {
-                        println("Click! isExtended before: $isExtended")
-                        onClickMore()
-                    },
+                    .fillMaxWidth(),
             ) {
                 Image(
                     painter = painterResource(R.drawable.ellipse),


### PR DESCRIPTION
## ANDR-24
### 🧩 Что сделано:

- Убрана кликабельность у текста-названия 
- Навешена кликабельность на весь элемент вопроса/коллекции

### 🗂 Затронутые модули:

Core -> ui

### 🎯 Цель задачи:

Фикс бага, улучшение качества UI/UX


### Скрин к ANDR-24
![Untitled](https://github.com/user-attachments/assets/dd9e0dd2-411b-4558-bf5b-632839ebe694)
