### PR TITLE
ANDR-25 Изменила отступ текста ответа в соответствии с дизайном

### DIFF
--- a/core/ui/src/main/java/ru/yeahub/core_ui/component/DetailHeaderQuestion.kt
+++ b/core/ui/src/main/java/ru/yeahub/core_ui/component/DetailHeaderQuestion.kt
@@ -43,7 +43,7 @@ fun DetailHeaderQuestion(
                 spotColor = Theme.colors.mainShadow
             )
             .background(Theme.colors.white900, shape = RoundedCornerShape(12.dp))
-            .padding(start = 10.dp, top = 10.dp, end = 10.dp, bottom = 20.dp)
+            .padding(start = 17.dp, top = 10.dp, end = 17.dp, bottom = 20.dp)
     ) {
         Column {
             imageUrl?.let {

--- a/core/ui/src/main/java/ru/yeahub/core_ui/component/DetailedQuestionAnswer.kt
+++ b/core/ui/src/main/java/ru/yeahub/core_ui/component/DetailedQuestionAnswer.kt
@@ -71,7 +71,6 @@ private fun DetailedQuestionAnswerInternal(
     Column(
         modifier = modifier
             .fillMaxWidth()
-
             .background(Theme.colors.white900, RoundedCornerShape(12.dp))
             .padding(start = 17.dp, end = 17.dp, top = 20.dp, bottom = 20.dp)
     ) {

--- a/core/ui/src/main/java/ru/yeahub/core_ui/component/DetailedQuestionAnswer.kt
+++ b/core/ui/src/main/java/ru/yeahub/core_ui/component/DetailedQuestionAnswer.kt
@@ -72,7 +72,7 @@ private fun DetailedQuestionAnswerInternal(
         modifier = modifier
             .fillMaxWidth()
             .background(Theme.colors.white900, RoundedCornerShape(12.dp))
-            .padding(16.dp)
+            .padding(start = 17.dp, end = 17.dp, top = 20.dp, bottom = 20.dp)
     ) {
         Text(
             text = stringResource(R.string.expanded_answer_title),
@@ -82,8 +82,9 @@ private fun DetailedQuestionAnswerInternal(
         )
 
         Column(
-            modifier = modifier
+            modifier = Modifier
                 .verticalScroll(rememberScrollState())
+                .fillMaxWidth()
                 .animateContentSize()
         ) {
             if (isExpanded) {

--- a/core/ui/src/main/java/ru/yeahub/core_ui/component/DetailedQuestionAnswer.kt
+++ b/core/ui/src/main/java/ru/yeahub/core_ui/component/DetailedQuestionAnswer.kt
@@ -71,6 +71,7 @@ private fun DetailedQuestionAnswerInternal(
     Column(
         modifier = modifier
             .fillMaxWidth()
+
             .background(Theme.colors.white900, RoundedCornerShape(12.dp))
             .padding(start = 17.dp, end = 17.dp, top = 20.dp, bottom = 20.dp)
     ) {

--- a/core/ui/src/main/java/ru/yeahub/core_ui/component/ShortQuestionAnswer.kt
+++ b/core/ui/src/main/java/ru/yeahub/core_ui/component/ShortQuestionAnswer.kt
@@ -34,7 +34,7 @@ fun ShortQuestionAnswer(
                 spotColor = Theme.colors.mainShadow,
             )
             .background(Theme.colors.white900, shape = RoundedCornerShape(12.dp))
-            .padding(start = 10.dp, end = 10.dp, top = 20.dp, bottom = 20.dp)
+            .padding(start = 17.dp, end = 17.dp, top = 20.dp, bottom = 20.dp)
     ) {
         Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),

--- a/feature/detail-question/impl/src/main/java/ru/yeahub/detail_question/impl/presentation/view/QuestionContent.kt
+++ b/feature/detail-question/impl/src/main/java/ru/yeahub/detail_question/impl/presentation/view/QuestionContent.kt
@@ -52,7 +52,7 @@ fun QuestionContent(
             Box(
                 modifier = Modifier
                     .background(Color.Transparent)
-                    .padding(10.dp, 16.dp)
+                    .padding(16.dp, 16.dp)
             ) {
                 DetailHeaderQuestion(
                     questionTitle = question.title,
@@ -66,7 +66,7 @@ fun QuestionContent(
             Box(
                 modifier = Modifier
                     .background(Color.Transparent)
-                    .padding(start = 10.dp, end = 10.dp, bottom = 20.dp)
+                    .padding(start = 16.dp, end = 16.dp, bottom = 20.dp)
                     .height(IntrinsicSize.Min)
             ) {
                 question.shortAnswer?.let {
@@ -81,7 +81,7 @@ fun QuestionContent(
                 blocks = blocks,
                 modifier = Modifier
                     .height(IntrinsicSize.Min)
-                    .padding(start = 10.dp, end = 10.dp, bottom = 20.dp)
+                    .padding(start = 16.dp, end = 16.dp, bottom = 20.dp)
             )
         }
         item {


### PR DESCRIPTION
🧩 Что сделано:
Изменила отступы в нескольких файлах в соответствии с дизайном.
Убрано дублирование modifier в скролле.

🗂 Затронутые модули:
feature -> detail-question-impl -> presentation

🎯 Цель задачи:
Улучшение внешнего вида страницы с описанием ответа
![Снимок1](https://github.com/user-attachments/assets/241467a2-b00b-4606-b675-e16591248a82)
