### PR TITLE
ANDR-30 Подтянуть версию gradle + фикс layout inspector

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,7 +21,15 @@ android {
 
     packaging {
         resources {
-            resources.excludes.add("META-INF/*")
+            resources.excludes.add("META-INF/LICENSE.md")
+            resources.excludes.add("META-INF/LICENSE-notice.md")
+            resources.excludes.add("META-INF/LICENSE")
+            resources.excludes.add("META-INF/LICENSE.txt")
+            resources.excludes.add("META-INF/NOTICE")
+            resources.excludes.add("META-INF/NOTICE.txt")
+            resources.excludes.add("META-INF/DEPENDENCIES")
+            resources.excludes.add("META-INF/AL2.0")
+            resources.excludes.add("META-INF/LGPL2.1")
         }
     }
 

--- a/feature/selection-specializations/impl/build.gradle.kts
+++ b/feature/selection-specializations/impl/build.gradle.kts
@@ -17,7 +17,15 @@ android {
 
     packaging {
         resources {
-            resources.excludes.add("META-INF/*")
+            resources.excludes.add("META-INF/LICENSE.md")
+            resources.excludes.add("META-INF/LICENSE-notice.md")
+            resources.excludes.add("META-INF/LICENSE")
+            resources.excludes.add("META-INF/LICENSE.txt")
+            resources.excludes.add("META-INF/NOTICE")
+            resources.excludes.add("META-INF/NOTICE.txt")
+            resources.excludes.add("META-INF/DEPENDENCIES")
+            resources.excludes.add("META-INF/AL2.0")
+            resources.excludes.add("META-INF/LGPL2.1")
         }
     }
 

--- a/feature/selection-specializations/impl/build.gradle.kts
+++ b/feature/selection-specializations/impl/build.gradle.kts
@@ -89,3 +89,7 @@ dependencies {
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/feature/selection-specializations/impl/src/test/java/test/SpecializationSelectionMapperTest.kt
+++ b/feature/selection-specializations/impl/src/test/java/test/SpecializationSelectionMapperTest.kt
@@ -20,9 +20,8 @@ import test.SpecializationExampleDataClasses.defaultSpecialResponseWithImage
 import test.SpecializationExampleDataClasses.defaultVoSpecialization
 import test.SpecializationExampleDataClasses.defaultVoSpecializationWithImage
 
-class SpecializationSelectionMapperTest(
-    private val toDomainMapper: SpecializationSelectionDataToDomainMapper
-) {
+class SpecializationSelectionMapperTest {
+    private val toDomainMapper = SpecializationSelectionDataToDomainMapper()
 
     class ArgumentsProvider1 : TestArgumentsProvider<SpecializationSelectionDataToDomainMapperTestCase1>(){
         override fun testCases(): List<SpecializationSelectionDataToDomainMapperTestCase1> = listOf(

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Jun 02 21:49:49 MSK 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Что сделано: 

- Поднята минимальная версия gradle до последней stable 9.2.1
- Исправлена ошибка с работой layout inspetcor'a 

Исключены конфликтующие файлы лицензий, но НЕ исключены файлы версий (*.version) которые нужны для корректной работы Layout Inspector
В app & feature:selection-specializations модулях ранее были исключены все файлы

После фикса: 
<img width="798" height="1326" alt="image" src="https://github.com/user-attachments/assets/0137e15e-5410-4389-84ae-d801f14e1e2a" />
 <img width="801" height="1241" alt="image" src="https://github.com/user-attachments/assets/4e591d60-1863-4a26-bce1-3a786f4a4154" />
