### PR TITLE
ANDR-16: Пофикшены окончания вопросов в коллекциях

### DIFF
--- a/core/ui/src/main/java/ru/yeahub/core_ui/component/CollectionCard.kt
+++ b/core/ui/src/main/java/ru/yeahub/core_ui/component/CollectionCard.kt
@@ -103,7 +103,7 @@ fun CollectionCardPreview() {
         collectionTitle = "Собеседование на Middle + Frontend Разработчика в Сбер",
         descriptionText = "Техническое собеседование для экспертов по основным вопросам React",
         imageUrl = "123",
-        questionsCount = 11,
+        questionsCount = 30,
         onCollectionClick = {
         }
     )

--- a/core/ui/src/main/java/ru/yeahub/core_ui/component/CollectionCard.kt
+++ b/core/ui/src/main/java/ru/yeahub/core_ui/component/CollectionCard.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
@@ -87,7 +87,7 @@ fun CollectionCard(
                     contentDescription = null
                 )
                 Text(
-                    text = stringResource(R.string.questions, questionsCount),
+                    text = pluralStringResource(R.plurals.questions_count, questionsCount, questionsCount),
                     style = Theme.typography.body1,
                     color = Theme.colors.purple700
                 )
@@ -103,7 +103,7 @@ fun CollectionCardPreview() {
         collectionTitle = "Собеседование на Middle + Frontend Разработчика в Сбер",
         descriptionText = "Техническое собеседование для экспертов по основным вопросам React",
         imageUrl = "123",
-        questionsCount = 30,
+        questionsCount = 11,
         onCollectionClick = {
         }
     )

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -13,7 +13,6 @@
     <string name="difficulty">Сложность:</string>
     <string name="read_more">Подробнее</string>
     <string name="go_to_questions">Перейти к вопросам</string>
-    <string name="questions">%1$d вопросов</string>
     <string name="question_title">Сервис подготовки к собеседованиям</string>
     <string name="question_description">Готовьтесь к собеседованию с подборками вопросов из крупных IT-компаний. Узнайте, какие вопросы задают в Сбере, Т-Банке, Яндексе, Авито, Ozon, VK и других компаниях.</string>
     <string name="base_questions_title">База вопросов</string>
@@ -24,4 +23,10 @@
     <string name="error_screen_title_text">УПС!</string>
     <string name="on_back_button_text">Назад</string>
     <string name="unknown_error_screen_text">Не удалось загрузить данные</string>
+    <plurals name="questions_count">
+        <item quantity="one">%1$d вопрос</item>
+        <item quantity="few">%1$d вопроса</item>
+        <item quantity="many">%1$d вопросов</item>
+        <item quantity="other">%1$d вопросов</item>
+    </plurals>
 </resources>


### PR DESCRIPTION
🧩 Что сделано:
Использованы pluralStringResource вместо stringResource, встроенный способ работы с окончаниями, имеет свои правила для каждого языка, в CollectionCard используемой в коллекциях. 
Добавлены соответствующие строки в ресурсы.

🗂 Затронутые модули:
core -> ui 

🎯 Цель задачи:
Добавить склонения к "вопросы" в коллекциях


Если системный язык русский - всё работает как задумано.
<img width="576" height="1280" alt="image" src="https://github.com/user-attachments/assets/4f778bf3-290d-4ee3-9b3f-225b32a35abf" />

На английском языке системы решение ломается(скрин 2), т.к. у нас  сейчас нет английской локализации и к русским словам применяется английское правило. (когда появится локализация - всё будет работать как задумано (question - questions))
<img width="576" height="1280" alt="image" src="https://github.com/user-attachments/assets/fb2cb68f-eb0d-4ebf-9b95-698d4fa1bc6c" />
