### PR TITLE
 ANDR-14 Баги с UI/UX 

### DIFF
--- a/core/navigation-impl/src/main/java/ru/yeahub/navigation_impl/AppNavigation.kt
+++ b/core/navigation-impl/src/main/java/ru/yeahub/navigation_impl/AppNavigation.kt
@@ -5,8 +5,13 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
@@ -83,7 +88,7 @@ fun AppNavigation(
     }
 
     Scaffold(
-        modifier = modifier,
+        modifier = modifier.windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)),
         bottomBar = {
             NavigationBar(
                 modifier = Modifier.clip(RoundedCornerShape(12.dp)),

--- a/core/navigation-impl/src/main/java/ru/yeahub/navigation_impl/AppNavigation.kt
+++ b/core/navigation-impl/src/main/java/ru/yeahub/navigation_impl/AppNavigation.kt
@@ -5,13 +5,8 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
@@ -88,7 +83,7 @@ fun AppNavigation(
     }
 
     Scaffold(
-        modifier = modifier.windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)),
+        modifier = modifier,
         bottomBar = {
             NavigationBar(
                 modifier = Modifier.clip(RoundedCornerShape(12.dp)),

--- a/core/navigation-impl/src/main/java/ru/yeahub/navigation_impl/AppNavigation.kt
+++ b/core/navigation-impl/src/main/java/ru/yeahub/navigation_impl/AppNavigation.kt
@@ -246,10 +246,8 @@ private fun registerChildFeatures(
         val dependentRootFeatures = childFeature.getDependentRootFeatures(rootFeatures)
 
         // Если фича не указала зависимости, регистрируем для всех корневых фич
-        val targetRootFeatures = if (dependentRootFeatures.isEmpty()) {
+        val targetRootFeatures = dependentRootFeatures.ifEmpty {
             rootFeatures
-        } else {
-            dependentRootFeatures
         }
 
         targetRootFeatures.forEach { rootFeature ->

--- a/core/navigation-impl/src/main/java/ru/yeahub/navigation_impl/AppNavigation.kt
+++ b/core/navigation-impl/src/main/java/ru/yeahub/navigation_impl/AppNavigation.kt
@@ -5,8 +5,13 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
@@ -69,7 +74,7 @@ fun AppNavigation(
     val features: Set<FeatureApi> = getKoin().getAll<FeatureApi>().toSet()
     Timber.d("AppNavigation onCreate: Loaded features: ${features.map { it.javaClass.simpleName }}")
     val navItems = getBottomNavItems()
-    
+
     features.forEach { feature ->
         feature.initialize(pathManager)
     }
@@ -77,13 +82,13 @@ fun AppNavigation(
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
     val selectedRoute = getSelectedRoute(currentRoute, navItems)
-    
+
     currentRoute?.let { route ->
         pathManager.setCurrentPath(route)
     }
 
     Scaffold(
-        modifier = modifier,
+        modifier = modifier.windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal)),
         bottomBar = {
             NavigationBar(
                 modifier = Modifier.clip(RoundedCornerShape(12.dp)),
@@ -184,9 +189,9 @@ private fun handleBottomNavClick(
         // Навигируем на родительский маршрут другого таба
         Timber.d(
             "AppNavigation onClick: Navigating to different tab: " +
-                "${item.route} from: $currentRoute"
+                    "${item.route} from: $currentRoute"
         )
-        
+
         // Устанавливаем новый корневой путь
         pathManager.setCurrentPath(item.route)
         navController.navigate(item.route) {
@@ -208,21 +213,21 @@ private fun registerDynamicNavigation(
 ) {
     val rootFeatures = features.filter { it.isRootFeature() }
     val childFeatures = features.filter { !it.isRootFeature() }
-    
+
     // Регистрируем корневые фичи
     rootFeatures.forEach { feature ->
         Timber.d(
             "AppNavigation registerGraph: Registering root feature: " +
                     "${feature.javaClass.simpleName}"
         )
-        
+
         // Сбрасываем путь для корневой фичи
         pathManager.setCurrentPath("")
         pathManager.registerFeaturePath(feature.getFeatureName(), feature.getFeatureName())
-        
+
         feature.registerGraph(navGraphBuilder, navController, pathManager)
     }
-    
+
     // Регистрируем дочерние фичи для каждой корневой фичи
     registerChildFeatures(childFeatures, rootFeatures, pathManager, navController, navGraphBuilder)
 }
@@ -239,17 +244,17 @@ private fun registerChildFeatures(
 ) {
     childFeatures.forEach { childFeature ->
         val dependentRootFeatures = childFeature.getDependentRootFeatures(rootFeatures)
-        
+
         // Если фича не указала зависимости, регистрируем для всех корневых фич
         val targetRootFeatures = if (dependentRootFeatures.isEmpty()) {
             rootFeatures
         } else {
             dependentRootFeatures
         }
-        
+
         targetRootFeatures.forEach { rootFeature ->
             pathManager.setCurrentPath(rootFeature.getFeatureName())
-            
+
             // Регистрируем дочернюю фичу
             childFeature.registerGraph(
                 navGraphBuilder = navGraphBuilder,

--- a/feature/public-collections/impl/src/main/java/ru/yeahub/public_collections/PublicCollectionsFeatureImpl.kt
+++ b/feature/public-collections/impl/src/main/java/ru/yeahub/public_collections/PublicCollectionsFeatureImpl.kt
@@ -1,5 +1,6 @@
 package ru.yeahub.public_collections
 
+import android.net.Uri
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
@@ -67,8 +68,9 @@ class PublicCollectionsFeatureImpl : FeatureApi {
         collectionId: String,
         title: String
     ) {
+        val encodedTitle = Uri.encode(title)
         val questionsRoute = "collections/${FeatureRoute.PublicQuestionsFeature.FEATURE_NAME}" +
-                "?tittle=$title" + "&idCollection=$collectionId"
+                "?tittle=$encodedTitle" + "&idCollection=$collectionId"
 
         Timber.d(
             "PublicCollectionsFeatureImpl" +

--- a/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/data/repository/remote/PublicQuestionsRemoteDataSource.kt
+++ b/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/data/repository/remote/PublicQuestionsRemoteDataSource.kt
@@ -16,6 +16,7 @@ class PublicQuestionsRemoteDataSource(private val apiService: NetworkProvider) :
             page = page,
             limit = limit,
             skillFilterMode = skillFilterMode,
+            collection = idCollection,
             specialization = idSpecialization
         )
     }

--- a/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/screen/PublicQuestionsScreen.kt
+++ b/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/presentation/screen/PublicQuestionsScreen.kt
@@ -348,10 +348,6 @@ private fun PaginationFooter(
                 }
             }
 
-            isEndReached -> {
-                Text(stringResource(id = R.string.error))
-            }
-
             else -> {
                 Spacer(modifier = Modifier.height(0.dp))
             }


### PR DESCRIPTION
Задача: https://tracker.yandex.ru/ANDR-14

Баги: 
 * "Во вкладке «Вопросы» при выборе любой специализации отображаются все вопросы, а не только конкретной специализации."
 ### **Не бага** 
 Бэк отдает одни и те же вопросы на разных экранах "Вопросы". Тк сортировки нет, 1ые вопросы всегда идут про git
 
 
 
 * Во вкладке «Вопросы» при выборе специализации в конце списка вопросов отображается «Ошибка». - исправлено
 ### **Fixed** 
 До: 
<img width="396" height="713" alt="image" src="https://github.com/user-attachments/assets/2b97aa23-d9de-42a8-9842-0d342aa19493" />

После: 
<img width="357" height="755" alt="image" src="https://github.com/user-attachments/assets/bd9f9f50-bddf-4b0e-848a-35365ccccf2f" />




 * В "Коллекции" указано 0 вопросов, при переходе в нее отображается список всех вопросов
 ### **Fixed** 
 Было: 
 1. Слали запрос https://api.yeatwork.ru/collections/public?page=1&limit=10&specializations=19&isFree=true 
 2. Слали запрос https://api.yeatwork.ru/questions/public-questions?page=1&limit=10&skillFilterMode=ANY 
 В итоге на бэке уходил запрос без фильтрации по конкретной коллекции что и приводило к ошибке
 
 Стало: 
 1. запрос так и шлем
 2. Добавлен параметр collection=collectionId из запроса №1 
 Результат: 
<img width="345" height="754" alt="image" src="https://github.com/user-attachments/assets/2bab8674-0618-4123-b671-cfe97e712383" />
<img width="367" height="759" alt="image" src="https://github.com/user-attachments/assets/7ee081b9-e765-41e2-b8af-5b9851f5810c" />




 * При горизонтальном повороте часть контента перекрыта камерой на устройстве
 ### **Fixed** 
Добавлен общий отступ в горизонтальном режиме 
<img width="452" height="230" alt="image" src="https://github.com/user-attachments/assets/95fcdd46-49e3-4fe8-937d-dc1d5ad5c1cf" />
<img width="451" height="231" alt="image" src="https://github.com/user-attachments/assets/dbb211d6-a508-46b2-a25a-efd0a9d8274d" />

