### PR TITLE
ANDR-92: Фикс багов для MVP

### DIFF
--- a/core/network-api/src/main/java/ru/yeahub/network_api/ApiService.kt
+++ b/core/network-api/src/main/java/ru/yeahub/network_api/ApiService.kt
@@ -20,7 +20,7 @@ interface ApiService {
         collection: Int? = null,
         rate: List<Int>? = null,
         keywords: List<String>? = null,
-        specialization: Int? = null,
+        specializationId: Int? = null,
         orderBy: String? = null,
         order: String? = null,
         random: Boolean? = null

--- a/core/network-impl/src/main/java/ru/yeahub/network_impl/RetrofitApiService.kt
+++ b/core/network-impl/src/main/java/ru/yeahub/network_impl/RetrofitApiService.kt
@@ -25,7 +25,7 @@ interface RetrofitApiService : ApiService {
         @Query("collection") collection: Int?,
         @Query("rate") rate: List<Int>?,
         @Query("keywords") keywords: List<String>?,
-        @Query("specialization") specialization: Int?,
+        @Query("specializationId") specializationId: Int?,
         @Query("orderBy") orderBy: String?,
         @Query("order") order: String?,
         @Query("random") random: Boolean?

--- a/core/ui/src/main/java/ru/yeahub/core_ui/component/CollectionCard.kt
+++ b/core/ui/src/main/java/ru/yeahub/core_ui/component/CollectionCard.kt
@@ -17,12 +17,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import ru.yeahub.core_ui.example.staticPreview.StaticPreview
 import ru.yeahub.core_ui.theme.Theme
+import ru.yeahub.core_utils.common.RussianPluralForms
+import ru.yeahub.core_utils.common.formatRussianCount
 import ru.yeahub.ui.R
 
 @Composable
@@ -87,7 +88,10 @@ fun CollectionCard(
                     contentDescription = null
                 )
                 Text(
-                    text = pluralStringResource(R.plurals.questions_count, questionsCount, questionsCount),
+                    text = formatRussianCount(
+                        count = questionsCount,
+                        forms = QUESTION_COUNT_WORD_FORMS,
+                    ),
                     style = Theme.typography.body1,
                     color = Theme.colors.purple700
                 )
@@ -108,3 +112,9 @@ fun CollectionCardPreview() {
         }
     )
 }
+
+private val QUESTION_COUNT_WORD_FORMS = RussianPluralForms(
+    one = "вопрос",
+    few = "вопроса",
+    many = "вопросов",
+)

--- a/core/ui/src/main/java/ru/yeahub/core_ui/component/CollectionCard.kt
+++ b/core/ui/src/main/java/ru/yeahub/core_ui/component/CollectionCard.kt
@@ -17,12 +17,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import ru.yeahub.core_ui.example.staticPreview.StaticPreview
 import ru.yeahub.core_ui.theme.Theme
+import ru.yeahub.core_utils.common.RussianPluralForms
+import ru.yeahub.core_utils.common.formatRussianCount
 import ru.yeahub.ui.R
 
 @Composable
@@ -34,6 +36,12 @@ fun CollectionCard(
     questionsCount: Int,
     onCollectionClick: () -> Unit,
 ) {
+    val questionCountWordForms = RussianPluralForms(
+        one = stringResource(R.string.question_count_word_one),
+        few = stringResource(R.string.question_count_word_few),
+        many = stringResource(R.string.question_count_word_many),
+    )
+
     Card(
         modifier = modifier.fillMaxWidth(),
         shape = RoundedCornerShape(8.dp),
@@ -87,10 +95,9 @@ fun CollectionCard(
                     contentDescription = null
                 )
                 Text(
-                    text = pluralStringResource(
-                        id = R.plurals.questions_count,
+                    text = formatRussianCount(
                         count = questionsCount,
-                        questionsCount
+                        forms = questionCountWordForms,
                     ),
                     style = Theme.typography.body1,
                     color = Theme.colors.purple700

--- a/core/ui/src/main/java/ru/yeahub/core_ui/component/CollectionCard.kt
+++ b/core/ui/src/main/java/ru/yeahub/core_ui/component/CollectionCard.kt
@@ -17,13 +17,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import ru.yeahub.core_ui.example.staticPreview.StaticPreview
 import ru.yeahub.core_ui.theme.Theme
-import ru.yeahub.core_utils.common.RussianPluralForms
-import ru.yeahub.core_utils.common.formatRussianCount
 import ru.yeahub.ui.R
 
 @Composable
@@ -88,9 +87,10 @@ fun CollectionCard(
                     contentDescription = null
                 )
                 Text(
-                    text = formatRussianCount(
+                    text = pluralStringResource(
+                        id = R.plurals.questions_count,
                         count = questionsCount,
-                        forms = QUESTION_COUNT_WORD_FORMS,
+                        questionsCount
                     ),
                     style = Theme.typography.body1,
                     color = Theme.colors.purple700
@@ -112,9 +112,3 @@ fun CollectionCardPreview() {
         }
     )
 }
-
-private val QUESTION_COUNT_WORD_FORMS = RussianPluralForms(
-    one = "вопрос",
-    few = "вопроса",
-    many = "вопросов",
-)

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -23,6 +23,9 @@
     <string name="error_screen_title_text">УПС!</string>
     <string name="on_back_button_text">Назад</string>
     <string name="unknown_error_screen_text">Не удалось загрузить данные</string>
+    <string name="question_count_word_one">вопрос</string>
+    <string name="question_count_word_few">вопроса</string>
+    <string name="question_count_word_many">вопросов</string>
     <plurals name="questions_count">
         <item quantity="one">%1$d вопрос</item>
         <item quantity="few">%1$d вопроса</item>

--- a/core/utils/src/main/java/ru/yeahub/core_utils/common/RussianPluralFormatter.kt
+++ b/core/utils/src/main/java/ru/yeahub/core_utils/common/RussianPluralFormatter.kt
@@ -1,0 +1,38 @@
+package ru.yeahub.core_utils.common
+
+import kotlin.math.abs
+
+private const val TEENS_START = 11
+private const val TEENS_END = 14
+private const val LAST_TWO_DIGITS_BASE = 100
+private const val LAST_DIGIT_BASE = 10
+private const val ONE_ITEM_LAST_DIGIT = 1
+private const val FEW_ITEMS_LAST_DIGIT_START = 2
+private const val FEW_ITEMS_LAST_DIGIT_END = 4
+
+data class RussianPluralForms(
+    val one: String,
+    val few: String,
+    val many: String,
+)
+
+fun formatRussianCount(
+    count: Int,
+    forms: RussianPluralForms,
+): String = "$count ${selectRussianPluralForm(count, forms)}"
+
+private fun selectRussianPluralForm(
+    count: Int,
+    forms: RussianPluralForms,
+): String {
+    val absoluteCount = abs(count)
+    val lastTwoDigits = absoluteCount % LAST_TWO_DIGITS_BASE
+    val lastDigit = absoluteCount % LAST_DIGIT_BASE
+
+    return when {
+        lastTwoDigits in TEENS_START..TEENS_END -> forms.many
+        lastDigit == ONE_ITEM_LAST_DIGIT -> forms.one
+        lastDigit in FEW_ITEMS_LAST_DIGIT_START..FEW_ITEMS_LAST_DIGIT_END -> forms.few
+        else -> forms.many
+    }
+}

--- a/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/data/repository/remote/PublicQuestionsRemoteDataSource.kt
+++ b/feature/public-questions/impl/src/main/java/ru/yeahub/public_questions/impl/data/repository/remote/PublicQuestionsRemoteDataSource.kt
@@ -17,7 +17,7 @@ class PublicQuestionsRemoteDataSource(private val apiService: NetworkProvider) :
             limit = limit,
             skillFilterMode = skillFilterMode,
             collection = idCollection,
-            specialization = idSpecialization
+            specializationId = idSpecialization
         )
     }
 }


### PR DESCRIPTION
🧩 Что сделано:

- исправлен query-параметр фильтра специализации: specialization -> specializationId
- синхронизирован контракт API и datasource
вопросы теперь фильтруются по выбранной специальности корректно

До: 
<img width="1226" height="2559" alt="Screenshot_20260304_190923" src="https://github.com/user-attachments/assets/075a7f38-5e6a-4f48-8a4e-34686de2069a" />
После:
<img width="1226" height="2559" alt="Screenshot_20260304_194927" src="https://github.com/user-attachments/assets/d4c91a8d-0b0a-4a4e-90af-5d9aced09545" />


- добавлен форматтер русских склонений для числительных
отображение количества вопросов переведено на корректные формы (1 вопрос, 2 вопроса, 5 вопросов)

До:
<img width="1226" height="2559" alt="Screenshot_20260304_191115" src="https://github.com/user-attachments/assets/1de49662-0fef-4acc-b3c7-88cd85dd9cb0" />
(см 3 вопросов)

После:
<img width="1226" height="2559" alt="Screenshot_20260304_192624" src="https://github.com/user-attachments/assets/82622365-c14b-4f28-a029-493bc760db5a" />

🗂 Затронутые модули:

core/ui
core/network/api, core/network/impl
feature/public-questions/impl

core/utils (для форматтера)

🎯 Цель задачи: фикс багов для  MVP

_______________________________

Отчет по багу с числом коллекций: 

🫡 Специализация React Frontend
Коллекция СбербанкМой1 показывает 0 вопросов -> проваливаемся внутрь -> есть 1 вопрос 

Тестировались запросы с параметрами: 
/collections/public ... specializations=11 ...
для collectionId=80 (СбербанкМой1) -> questionsCount: 0

/questions/public-questions?collection=80&specializationId=11...
-> total: 1, в data реально 1 вопрос (id 84)

🟰 Итог:
один и тот же набор фильтров,
два разных результата (0 и 1),
значит рассинхрон в backend-агрегации questionsCount в ручке коллекций. а не клиентский баг отображения.

📱 specId=11, collectionId=80
URL1: /collections/public?page=1&limit=100&specializations=11&isFree=true -> questionsCount=0
URL2: /questions/public-questions?page=1&limit=100&collection=80&specializationId=11 -> total=1
Ожидаемое: questionsCount должно быть 1.

<img width="1226" height="2559" alt="Screenshot_20260304_193507" src="https://github.com/user-attachments/assets/430b3e24-73b9-4edb-8975-19f9753c8fd4" />
<img width="1226" height="2559" alt="Screenshot_20260304_193536" src="https://github.com/user-attachments/assets/43cf6bcc-e90a-492e-ace9-50ac4bb00f5e" />

👀Аналогично, в коллекции Middle Frontend разработчик в компанию Т-банк: 12 вопросов -> проваливаемся внутрь -> фактически  отображается 11 вопросов