### PR TITLE
[Публичный тренажер] ANDR-59: Второй этап InterviewQuizScreen. Data + Domain

### DIFF
--- a/core/network-api/src/main/java/ru/yeahub/network_api/ApiService.kt
+++ b/core/network-api/src/main/java/ru/yeahub/network_api/ApiService.kt
@@ -1,6 +1,7 @@
 package ru.yeahub.network_api
 
 import ru.yeahub.network_api.models.GetCollectionsResponse
+import ru.yeahub.network_api.models.GetNewMockQuizResponse
 import ru.yeahub.network_api.models.GetPublicQuestionResponse
 import ru.yeahub.network_api.models.GetPublicQuestionsResponse
 import ru.yeahub.network_api.models.GetSkillsResponse
@@ -51,4 +52,12 @@ interface ApiService {
         specializationsId: Long,
         isFree: Boolean
     ): GetCollectionsResponse
+
+    suspend fun getQuizMockQuestions(
+        skills: List<String>? =  null,
+        complexity: List<Int>? = null,
+        collection: Int? = null,
+        limit: Int? = null,
+        specialization: Int,
+    ): GetNewMockQuizResponse
 }

--- a/core/network-api/src/main/java/ru/yeahub/network_api/ApiService.kt
+++ b/core/network-api/src/main/java/ru/yeahub/network_api/ApiService.kt
@@ -54,10 +54,10 @@ interface ApiService {
     ): GetCollectionsResponse
 
     suspend fun getQuizMockQuestions(
-        skills: List<String>? =  null,
-        complexity: List<Int>? = null,
-        collection: Int? = null,
-        limit: Int? = null,
+        skills: List<String>?,
+        complexity: List<Int>?,
+        collection: Int?,
+        limit: Int?,
         specialization: Int,
     ): GetNewMockQuizResponse
 }

--- a/core/network-api/src/main/java/ru/yeahub/network_api/models/GetNewMockQuizResponse.kt
+++ b/core/network-api/src/main/java/ru/yeahub/network_api/models/GetNewMockQuizResponse.kt
@@ -1,0 +1,10 @@
+package ru.yeahub.network_api.models
+
+data class GetNewMockQuizResponse(
+    val id: String,
+    val startDate: String,
+    val fullCount: Int,
+    val skills: List<String>,
+    val response: List<QuestionAnswerDto>,
+    val questions: List<GetQuestionResponse>
+)

--- a/core/network-api/src/main/java/ru/yeahub/network_api/models/QuestionAnswerDto.kt
+++ b/core/network-api/src/main/java/ru/yeahub/network_api/models/QuestionAnswerDto.kt
@@ -1,0 +1,7 @@
+package ru.yeahub.network_api.models
+
+data class QuestionAnswerDto(
+    val questionId: Int,
+    val questionTitle: String,
+    val answer: String
+)

--- a/core/network-impl/src/main/java/ru/yeahub/network_impl/RetrofitApiService.kt
+++ b/core/network-impl/src/main/java/ru/yeahub/network_impl/RetrofitApiService.kt
@@ -5,6 +5,7 @@ import retrofit2.http.Path
 import retrofit2.http.Query
 import ru.yeahub.network_api.ApiService
 import ru.yeahub.network_api.models.GetCollectionsResponse
+import ru.yeahub.network_api.models.GetNewMockQuizResponse
 import ru.yeahub.network_api.models.GetPublicQuestionResponse
 import ru.yeahub.network_api.models.GetPublicQuestionsResponse
 import ru.yeahub.network_api.models.GetSkillsResponse
@@ -61,4 +62,13 @@ interface RetrofitApiService : ApiService {
         @Query("specializations") specializationsId: Long,
         @Query("isFree") isFree: Boolean
     ): GetCollectionsResponse
+
+    @GET("/interview-preparation/quizzes/mock/new")
+    override suspend fun getQuizMockQuestions(
+        @Query("skills") skills: List<String>?,
+        @Query("complexity") complexity: List<Int>?,
+        @Query("collection") collection: Int?,
+        @Query("limit") limit: Int?,
+        @Query("specialization") specialization: Int,
+    ): GetNewMockQuizResponse
 }

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/data/InterviewQuizDataToDomainMapper.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/data/InterviewQuizDataToDomainMapper.kt
@@ -2,17 +2,17 @@ package ru.yeahub.interview_trainer.impl.interviewQuiz.data
 
 import ru.yeahub.interview_trainer.impl.interviewQuiz.domain.DomainQuestion
 import ru.yeahub.interview_trainer.impl.interviewQuiz.domain.DomainQuestionsListResponse
-import ru.yeahub.network_api.models.GetPublicQuestionsResponse
+import ru.yeahub.network_api.models.GetNewMockQuizResponse
 import ru.yeahub.network_api.models.GetQuestionResponse
 
 class InterviewQuizDataToDomainMapper {
 
     fun mapDataListToDomainList(
-        dataResponse: GetPublicQuestionsResponse
+        dataResponse: GetNewMockQuizResponse
     ): DomainQuestionsListResponse {
         return DomainQuestionsListResponse(
-            total = dataResponse.total,
-            data = dataResponse.data.map { item -> dataToDomain(item) }
+            fullCount = dataResponse.fullCount,
+            questions = dataResponse.questions.map { item -> dataToDomain(item) }
         )
     }
 

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/data/InterviewQuizDataToDomainMapper.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/data/InterviewQuizDataToDomainMapper.kt
@@ -1,0 +1,26 @@
+package ru.yeahub.interview_trainer.impl.interviewQuiz.data
+
+import ru.yeahub.interview_trainer.impl.interviewQuiz.domain.DomainQuestion
+import ru.yeahub.interview_trainer.impl.interviewQuiz.domain.DomainQuestionsListResponse
+import ru.yeahub.network_api.models.GetPublicQuestionsResponse
+import ru.yeahub.network_api.models.GetQuestionResponse
+
+class InterviewQuizDataToDomainMapper {
+
+    fun mapDataListToDomainList(
+        dataResponse: GetPublicQuestionsResponse
+    ): DomainQuestionsListResponse {
+        return DomainQuestionsListResponse(
+            total = dataResponse.total,
+            data = dataResponse.data.map { item -> dataToDomain(item) }
+        )
+    }
+
+    private fun dataToDomain(data: GetQuestionResponse): DomainQuestion {
+        return DomainQuestion(
+            id = data.id,
+            title = data.title,
+            shortAnswer = data.shortAnswer ?: ""
+        )
+    }
+}

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/data/InterviewQuizRepositoryImpl.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/data/InterviewQuizRepositoryImpl.kt
@@ -13,9 +13,9 @@ class InterviewQuizRepositoryImpl(
     override suspend fun getQuestionsList(
         request: QuestionsRequest
     ): DomainQuestionsListResponse = mapper.mapDataListToDomainList(
-        dataResponse = networkProvider.apiService.getQuestions(
-            page = request.page,
-            limit = request.limit
+        dataResponse = networkProvider.apiService.getQuizMockQuestions(
+            limit = request.limit,
+            specialization = request.specialization
         )
     )
 }

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/data/InterviewQuizRepositoryImpl.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/data/InterviewQuizRepositoryImpl.kt
@@ -1,0 +1,21 @@
+package ru.yeahub.interview_trainer.impl.interviewQuiz.data
+
+import ru.yeahub.interview_trainer.impl.interviewQuiz.domain.DomainQuestionsListResponse
+import ru.yeahub.interview_trainer.impl.interviewQuiz.domain.InterviewQuizRepositoryApi
+import ru.yeahub.interview_trainer.impl.interviewQuiz.domain.QuestionsRequest
+import ru.yeahub.network_api.NetworkProvider
+
+class InterviewQuizRepositoryImpl(
+    private val networkProvider: NetworkProvider,
+    private val mapper: InterviewQuizDataToDomainMapper
+) : InterviewQuizRepositoryApi {
+
+    override suspend fun getQuestionsList(
+        request: QuestionsRequest
+    ): DomainQuestionsListResponse = mapper.mapDataListToDomainList(
+        dataResponse = networkProvider.apiService.getQuestions(
+            page = request.page,
+            limit = request.limit
+        )
+    )
+}

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/data/InterviewQuizRepositoryImpl.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/data/InterviewQuizRepositoryImpl.kt
@@ -14,6 +14,9 @@ class InterviewQuizRepositoryImpl(
         request: QuestionsRequest
     ): DomainQuestionsListResponse = mapper.mapDataListToDomainList(
         dataResponse = networkProvider.apiService.getQuizMockQuestions(
+            skills = null,
+            complexity = null,
+            collection = null,
             limit = request.limit,
             specialization = request.specialization
         )

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/domain/DomainQuestion.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/domain/DomainQuestion.kt
@@ -1,0 +1,7 @@
+package ru.yeahub.interview_trainer.impl.interviewQuiz.domain
+
+data class DomainQuestion(
+    val id: Long,
+    val title: String,
+    val shortAnswer: String
+)

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/domain/DomainQuestionsListResponse.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/domain/DomainQuestionsListResponse.kt
@@ -1,6 +1,6 @@
 package ru.yeahub.interview_trainer.impl.interviewQuiz.domain
 
 data class DomainQuestionsListResponse(
-    val total: Long,
-    val data: List<DomainQuestion>
+    val fullCount: Int,
+    val questions: List<DomainQuestion>
 )

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/domain/DomainQuestionsListResponse.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/domain/DomainQuestionsListResponse.kt
@@ -1,0 +1,6 @@
+package ru.yeahub.interview_trainer.impl.interviewQuiz.domain
+
+data class DomainQuestionsListResponse(
+    val total: Long,
+    val data: List<DomainQuestion>
+)

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/domain/GetQuestionsListUseCase.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/domain/GetQuestionsListUseCase.kt
@@ -1,0 +1,6 @@
+package ru.yeahub.interview_trainer.impl.interviewQuiz.domain
+
+interface GetQuestionsListUseCase {
+
+    suspend operator fun invoke(request: QuestionsRequest): DomainQuestionsListResponse
+}

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/domain/GetQuestionsListUseCaseImpl.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/domain/GetQuestionsListUseCaseImpl.kt
@@ -1,0 +1,9 @@
+package ru.yeahub.interview_trainer.impl.interviewQuiz.domain
+
+class GetQuestionsListUseCaseImpl(
+    private val repository: InterviewQuizRepositoryApi
+) : GetQuestionsListUseCase {
+
+    override suspend fun invoke(request: QuestionsRequest) =
+        repository.getQuestionsList(request)
+}

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/domain/InterviewQuizRepositoryApi.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/domain/InterviewQuizRepositoryApi.kt
@@ -1,0 +1,8 @@
+package ru.yeahub.interview_trainer.impl.interviewQuiz.domain
+
+interface InterviewQuizRepositoryApi {
+
+    suspend fun getQuestionsList(
+        request: QuestionsRequest
+    ): DomainQuestionsListResponse
+}

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/domain/QuestionsRequest.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/domain/QuestionsRequest.kt
@@ -1,0 +1,6 @@
+package ru.yeahub.interview_trainer.impl.interviewQuiz.domain
+
+data class QuestionsRequest(
+    val page: Int,
+    val limit: Int
+)

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/domain/QuestionsRequest.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuiz/domain/QuestionsRequest.kt
@@ -1,6 +1,6 @@
 package ru.yeahub.interview_trainer.impl.interviewQuiz.domain
 
 data class QuestionsRequest(
-    val page: Int,
-    val limit: Int
+    val limit: Int,
+    val specialization: Int,
 )

--- a/feature/interview-trainer/impl/src/test/java/test/InterviewQuizDataToDomainMapperTest.kt
+++ b/feature/interview-trainer/impl/src/test/java/test/InterviewQuizDataToDomainMapperTest.kt
@@ -1,0 +1,117 @@
+package test
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ArgumentsSource
+import ru.yeahub.interview_trainer.impl.interviewQuiz.data.InterviewQuizDataToDomainMapper
+import ru.yeahub.interview_trainer.impl.interviewQuiz.domain.DomainQuestion
+import ru.yeahub.interview_trainer.impl.interviewQuiz.domain.DomainQuestionsListResponse
+import ru.yeahub.network_api.models.GetNewMockQuizResponse
+import ru.yeahub.network_api.models.GetQuestionResponse
+import ru.yeahub.network_api.models.NestedUserReferenceDto
+import ru.yeahub.test.TestArgumentsProvider
+
+class InterviewQuizDataToDomainMapperTest {
+
+    private val dataToDomainMapper = InterviewQuizDataToDomainMapper()
+
+    @ParameterizedTest
+    @ArgumentsSource(ArgumentsProvider::class)
+    fun dataToDomainMappingTestCase(
+        testCase: DataToDomainMappingTestCase
+    ) {
+        val result = dataToDomainMapper.mapDataListToDomainList(testCase.dataToTest)
+        assertEquals(testCase.expectedResult, result)
+    }
+
+    object QuestionExamplesDataClasses {
+
+        private val defaultQuestionResponse = GetQuestionResponse(
+            id = 1,
+            title = "default question 0",
+            description = "default description",
+            code = "0101",
+            imageSrc = null,
+            keywords = null,
+            longAnswer = null,
+            shortAnswer = "default short answer",
+            status = null,
+            rate = null,
+            complexity = null,
+            createdById = "07.03.2026",
+            updatedById = null,
+            questionSpecializations = emptyList(),
+            questionSkills = emptyList(),
+            createdAt = "07.03.2026",
+            updatedAt = "07.03.2026",
+            createdBy = NestedUserReferenceDto("userId", "username"),
+            updatedBy = null
+        )
+
+        private val defaultDomainQuestion = DomainQuestion(
+            id = 1,
+            title = "default question 0",
+            shortAnswer = "default short answer"
+        )
+
+        private val defaultQuestionResponseWithLongAnswer = GetQuestionResponse(
+            id = 2,
+            title = "default question with long answer 1",
+            description = "default description",
+            code = "0102",
+            imageSrc = null,
+            keywords = null,
+            longAnswer = "default long answer",
+            shortAnswer = "default short answer",
+            status = null,
+            rate = null,
+            complexity = null,
+            createdById = "07.03.2026",
+            updatedById = null,
+            questionSpecializations = emptyList(),
+            questionSkills = emptyList(),
+            createdAt = "07.03.2026",
+            updatedAt = "07.03.2026",
+            createdBy = NestedUserReferenceDto("userId", "username"),
+            updatedBy = null
+        )
+
+        private val defaultDomainQuestionWithLongAnswer = DomainQuestion(
+            id = 2,
+            title = "default question with long answer 1",
+            shortAnswer = "default short answer"
+        )
+
+        val defaultNewMockQuizResponse = GetNewMockQuizResponse(
+            id = "0101010",
+            startDate = "01.01.2026",
+            fullCount = 2,
+            skills = emptyList(),
+            response = emptyList(),
+            questions = listOf(defaultQuestionResponse, defaultQuestionResponseWithLongAnswer),
+        )
+
+        val defaultDomainListResponse = DomainQuestionsListResponse(
+            fullCount = 2,
+            questions = listOf(defaultDomainQuestion, defaultDomainQuestionWithLongAnswer)
+        )
+    }
+
+    data class DataToDomainMappingTestCase(
+        val dataToTest: GetNewMockQuizResponse,
+        val expectedResult:  DomainQuestionsListResponse
+    )
+
+    class ArgumentsProvider:
+        TestArgumentsProvider<DataToDomainMappingTestCase>() {
+
+        override fun testCases(): List<DataToDomainMappingTestCase> {
+            return listOf(
+                DataToDomainMappingTestCase(
+                    dataToTest = QuestionExamplesDataClasses.defaultNewMockQuizResponse,
+                    expectedResult = QuestionExamplesDataClasses.defaultDomainListResponse
+                )
+            )
+        }
+    }
+}


### PR DESCRIPTION
## 🧩 Что сделано:

В domain:
- Создана сущность request: QuestionsRequest с нужными полями limit и specialization.
- Созданы сущности question и response: DomainQuestion и DomainQuestionsListResponse.
- Созданы usecase (api и impl) и repository(api):  GetQuestionsListUseCase, GetQuestionsListUseCaseImpl и InterviewQuizRepositoryApi.

В data:
- Реализован репозиторий из domain: InterviewQuizRepositoryImpl.
- Создан маппер data-to-domain: InterviewQuizDataToDomainMapper.

в core/network:
- Добавление метода в ApiService: getQuizMockQuestions.
- Созданы две новые модели: GetNewMockQuizResponse и QuestionAnswerDto.
- Оверрайд добавленного метода из ApiService в RetrofitApiService.

## 🗂 Затронутые модули:

- core/network-api
- core/network-impl
- feature/interview-trainer/impl

## 🎯 Цель задачи:

- Создание data и domain слоев для InterviewQuiz
