### PR TITLE
 [Редактирование профиля] ANDR-74: Верстка диалога подтверждения навигации

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .cxx
 local.properties
 /detekt-setting/baseline.xml
+/.claude

--- a/core/ui/src/main/java/ru/yeahub/core_ui/component/AlertDialog.kt
+++ b/core/ui/src/main/java/ru/yeahub/core_ui/component/AlertDialog.kt
@@ -27,13 +27,13 @@ fun UnsavedChangesDialog(
             )
         },
         dismissButton = {
-            PrimaryButton(onClick = onStay) {
+            PrimaryButton(onClick = onLeave) {
                 Text("Да")
             }
         },
         confirmButton = {
             OutlineButton(
-                onClick = onLeave,
+                onClick = onStay,
                 colors = YeahubButtonDefaults.secondaryOutlinedButtonColors(),
                 border = YeahubButtonDefaults.secondaryOutlineBorderDefaults(),
             ) {

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -45,6 +45,9 @@
     <string name="profile_link_placeholder">Ссылка</string>
     <string name="profile_remove_photo">Удалить фото</string>
     <string name="profile_personal_information">"Личная информация"</string>
+    <string name="error_max_length_30">"Максимальная длина 30 символов"</string>
+    <string name="error_minimal_length_2">"Минимальная длина 2 символа"</string>
+    <string name="error_max_length_255">"Максимальная длина 255 символов"</string>
     <string name="profile_about_me">Обо мне</string>
     <string name="profile_skills">Навыки</string>
     <string name="profile_photo_click_for_edit">Кликни для изменения</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -32,7 +32,8 @@
     <string name="profile_nickname_label">Никнейм *</string>
     <string name="profile_nickname_placeholder">Придумайте никнейм</string>
     <string name="profile_specialization_label">IT Специальность*</string>
-    <string name="profile_specialization_placeholder">Граф. дизайнер</string>
+    <string name="profile_specialization_placeholder">Выберите специализацию</string>
+    <string name="profile_change_specialization">Сменить специальность</string>
     <string name="profile_email_label">Email для связи</string>
     <string name="profile_email_placeholder">Email@gmail.com</string>
     <string name="profile_location_label">Локация</string>

--- a/core/ui/src/main/res/values/strings.xml
+++ b/core/ui/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="favorite">Избранное</string>
     <string name="previous">Предыдущий</string>
     <string name="next">Следующий</string>
+    <string name="save">Сохранить</string>
     <string name="expanded_answer_title">Развёрнутый ответ</string>
     <string name="expand">Развернуть</string>
     <string name="collapse">Свернуть</string>

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/presentation/ProfileEditState.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/presentation/ProfileEditState.kt
@@ -40,6 +40,7 @@ sealed interface ProfileEditState {
         val nickname: String,
         val specializationList: List<String>,
         val specialization: String,
+        val isSpecializationEditable: Boolean,
         val email: String,
         val location: String,
         val socialLinksUrlMap: PersistentMap<SocialLinks, String>,

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/presentation/ProfileEditState.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/presentation/ProfileEditState.kt
@@ -12,6 +12,7 @@ sealed interface ProfileEditState {
         val personalInfoState: PersonalInfoTabState,
         val aboutMeTabState: AboutMeTabState,
         val skillsTabState: SkillsTabState,
+        val hasUnsavedChanges: Boolean,
     ) : ProfileEditState
 
     data class Error(val throwable: Throwable) : ProfileEditState

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/presentation/ProfileEditState.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/presentation/ProfileEditState.kt
@@ -41,7 +41,7 @@ sealed interface ProfileEditState {
     data class PersonalInfoTabState(
         val avatarUrl: String?,
         val nickname: ValidatedField,
-        val specializationList: List<String>,
+        val specializationList: PersistentList<String>,
         val specialization: String,
         val isSpecializationEditable: Boolean,
         val email: String,

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/presentation/ProfileEditState.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/presentation/ProfileEditState.kt
@@ -2,6 +2,7 @@ package ru.yeahub.profile_edit.impl.presentation
 
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.PersistentMap
+import ru.yeahub.core_utils.common.TextOrResource
 
 sealed interface ProfileEditState {
 
@@ -35,15 +36,17 @@ sealed interface ProfileEditState {
         Dribble,
     }
 
+    data class ValidatedField(val value: String, val error: TextOrResource?)
+
     data class PersonalInfoTabState(
         val avatarUrl: String?,
-        val nickname: String,
+        val nickname: ValidatedField,
         val specializationList: List<String>,
         val specialization: String,
         val isSpecializationEditable: Boolean,
         val email: String,
-        val location: String,
-        val socialLinksUrlMap: PersistentMap<SocialLinks, String>,
+        val location: ValidatedField,
+        val socialLinks: PersistentMap<SocialLinks, ValidatedField>,
     )
 
     data class AboutMeTabState(val aboutMeField: String)

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/presentation/ProfileEditState.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/presentation/ProfileEditState.kt
@@ -9,11 +9,10 @@ sealed interface ProfileEditState {
     data object Loading : ProfileEditState
 
     data class Loaded(
-        val selectedTab: ProfileEditTabs,
         val personalInfoState: PersonalInfoTabState,
         val aboutMeTabState: AboutMeTabState,
         val skillsTabState: SkillsTabState,
-        val hasUnsavedChanges: Boolean,
+        val showUnsavedChangesDialog: Boolean,
     ) : ProfileEditState
 
     data class Error(val throwable: Throwable) : ProfileEditState

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/presentation/intents/ProfileEditScreenCommand.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/presentation/intents/ProfileEditScreenCommand.kt
@@ -3,7 +3,6 @@ package ru.yeahub.profile_edit.impl.presentation.intents
 import ru.yeahub.core_utils.common.TextOrResource
 
 sealed interface ProfileEditScreenCommand {
-    data object ShowUnsavedChangesDialog : ProfileEditScreenCommand
     data object ShowPhotoPicker : ProfileEditScreenCommand
     data class ShowError(val message: TextOrResource) : ProfileEditScreenCommand
 }

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/presentation/intents/ProfileEditScreenCommand.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/presentation/intents/ProfileEditScreenCommand.kt
@@ -1,6 +1,9 @@
 package ru.yeahub.profile_edit.impl.presentation.intents
 
-sealed interface ProfileEditScreenCommand {
+import ru.yeahub.core_utils.common.TextOrResource
 
-    data object ToDo : ProfileEditScreenCommand
+sealed interface ProfileEditScreenCommand {
+    data object ShowUnsavedChangesDialog : ProfileEditScreenCommand
+    data object ShowPhotoPicker : ProfileEditScreenCommand
+    data class ShowError(val message: TextOrResource) : ProfileEditScreenCommand
 }

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/presentation/intents/ProfileEditScreenEvent.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/presentation/intents/ProfileEditScreenEvent.kt
@@ -9,21 +9,22 @@ sealed interface ProfileEditScreenEvent {
     data class SwitchTab(val tab: ProfileEditState.ProfileEditTabs) : ProfileEditScreenEvent
     data object BackPressed : ProfileEditScreenEvent
     data object DiscardChanges : ProfileEditScreenEvent
+    data object UnsavedChangesDialogDismissed : ProfileEditScreenEvent
     data object SaveProfile : ProfileEditScreenEvent
 
     data object UploadAvatar : ProfileEditScreenEvent
-    data class OnAvatarSelected(val uri: Uri) : ProfileEditScreenEvent
+    data class AvatarSelected(val uri: Uri) : ProfileEditScreenEvent
     data object DeleteAvatar : ProfileEditScreenEvent
-    data class OnNicknameChanged(val nickname: String) : ProfileEditScreenEvent
+    data class NicknameChanged(val nickname: String) : ProfileEditScreenEvent
     data class ChooseSpecialization(val specialization: String) : ProfileEditScreenEvent
     data object CannotChangeSpecializationToast : ProfileEditScreenEvent
-    data class OnLocationChanged(val location: String) : ProfileEditScreenEvent
-    data class OnSocialLinkChanged(
+    data class LocationChanged(val location: String) : ProfileEditScreenEvent
+    data class SocialLinkChanged(
         val link: ProfileEditState.SocialLinks,
         val url: String,
     ) : ProfileEditScreenEvent
 
-    data class OnAboutMeChanged(val text: String) : ProfileEditScreenEvent
+    data class AboutMeChanged(val text: String) : ProfileEditScreenEvent
 
     data class AddSkill(val skill: ProfileEditState.Skill) : ProfileEditScreenEvent
     data class RemoveSkill(val skill: ProfileEditState.Skill) : ProfileEditScreenEvent

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/presentation/intents/ProfileEditScreenEvent.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/presentation/intents/ProfileEditScreenEvent.kt
@@ -25,6 +25,6 @@ sealed interface ProfileEditScreenEvent {
 
     data class AboutMeChanged(val text: String) : ProfileEditScreenEvent
 
-    data class AddSkill(val skill: ProfileEditState.Skill) : ProfileEditScreenEvent
+    data class AddSkill(val skillName: String) : ProfileEditScreenEvent
     data class RemoveSkill(val skill: ProfileEditState.Skill) : ProfileEditScreenEvent
 }

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/presentation/intents/ProfileEditScreenEvent.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/presentation/intents/ProfileEditScreenEvent.kt
@@ -1,5 +1,30 @@
 package ru.yeahub.profile_edit.impl.presentation.intents
 
+import android.net.Uri
+import ru.yeahub.profile_edit.impl.presentation.ProfileEditState
+
 sealed interface ProfileEditScreenEvent {
-    data object ToDo : ProfileEditScreenEvent
+
+    data object LoadData : ProfileEditScreenEvent
+    data class SwitchTab(val tab: ProfileEditState.ProfileEditTabs) : ProfileEditScreenEvent
+    data object BackPressed : ProfileEditScreenEvent
+    data object DiscardChanges : ProfileEditScreenEvent
+    data object SaveProfile : ProfileEditScreenEvent
+
+    data object UploadAvatar : ProfileEditScreenEvent
+    data class OnAvatarSelected(val uri: Uri) : ProfileEditScreenEvent
+    data object DeleteAvatar : ProfileEditScreenEvent
+    data class OnNicknameChanged(val nickname: String) : ProfileEditScreenEvent
+    data class ChooseSpecialization(val specialization: String) : ProfileEditScreenEvent
+    data object CannotChangeSpecializationToast : ProfileEditScreenEvent
+    data class OnLocationChanged(val location: String) : ProfileEditScreenEvent
+    data class OnSocialLinkChanged(
+        val link: ProfileEditState.SocialLinks,
+        val url: String,
+    ) : ProfileEditScreenEvent
+
+    data class OnAboutMeChanged(val text: String) : ProfileEditScreenEvent
+
+    data class AddSkill(val skill: ProfileEditState.Skill) : ProfileEditScreenEvent
+    data class RemoveSkill(val skill: ProfileEditState.Skill) : ProfileEditScreenEvent
 }

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/presentation/intents/ProfileEditScreenEvent.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/presentation/intents/ProfileEditScreenEvent.kt
@@ -6,7 +6,6 @@ import ru.yeahub.profile_edit.impl.presentation.ProfileEditState
 sealed interface ProfileEditScreenEvent {
 
     data object LoadData : ProfileEditScreenEvent
-    data class SwitchTab(val tab: ProfileEditState.ProfileEditTabs) : ProfileEditScreenEvent
     data object BackPressed : ProfileEditScreenEvent
     data object DiscardChanges : ProfileEditScreenEvent
     data object UnsavedChangesDialogDismissed : ProfileEditScreenEvent

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/presentation/intents/ProfileEditScreenResult.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/presentation/intents/ProfileEditScreenResult.kt
@@ -1,0 +1,6 @@
+package ru.yeahub.profile_edit.impl.presentation.intents
+
+sealed interface ProfileEditScreenResult {
+    data object NavigateBack : ProfileEditScreenResult
+    data object NavigateToProfile : ProfileEditScreenResult
+}

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/CommonUiComponents.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/CommonUiComponents.kt
@@ -1,11 +1,18 @@
 package ru.yeahub.profile_edit.impl.ui
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import ru.yeahub.core_ui.component.textInput.DefaultTextField
 import ru.yeahub.core_ui.theme.Theme
+import ru.yeahub.core_utils.common.TextOrResource
+import ru.yeahub.profile_edit.impl.presentation.ProfileEditState
 
 @Composable
 internal fun SectionTitle(
@@ -30,5 +37,38 @@ internal fun FieldLabel(
         style = Theme.typography.body7,
         color = Theme.colors.black900,
         modifier = modifier.padding(bottom = 4.dp),
+    )
+}
+
+@Composable
+internal fun ValidatedTextField(
+    field: ProfileEditState.ValidatedField,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    modifier: Modifier = Modifier,
+) {
+    DefaultTextField(
+        value = field.value,
+        onValueChange = onValueChange,
+        placeholder = placeholder,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(52.dp),
+        onExpandedChange = {},
+        isError = field.error != null,
+    )
+    Box(modifier = Modifier.height(16.dp)) {
+        if (field.error != null) {
+            ValidationErrorText(error = field.error)
+        }
+    }
+}
+
+@Composable
+private fun ValidationErrorText(error: TextOrResource) {
+    Text(
+        text = error.getString(LocalContext.current),
+        style = Theme.typography.body7Alt,
+        color = Theme.colors.red700,
     )
 }

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/ProfileEditScreen.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/ProfileEditScreen.kt
@@ -78,7 +78,6 @@ fun ProfileEditScreen(
     )
     val coroutineScope = rememberCoroutineScope()
 
-
     Scaffold(
         containerColor = Theme.colors.black10,
         topBar = {
@@ -117,7 +116,6 @@ fun ProfileEditScreen(
                         vertical = 16.dp,
                     ),
             ) {
-
                 LaunchedEffect(state.selectedTab) {
                     if (pagerState.currentPage != state.selectedTab.ordinal) {
                         pagerState.animateScrollToPage(state.selectedTab.ordinal)

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/ProfileEditScreen.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/ProfileEditScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
@@ -50,7 +49,6 @@ import ru.yeahub.ui.R
 fun ProfileEditScreen(
     tabs: List<ProfileEditTabs>,
     state: ProfileEditState.Loaded,
-    showUnsavedChangesDialog: Boolean,
     onEvent: (ProfileEditScreenEvent) -> Unit,
     headerText: TextOrResource,
     personalInfoContent: @Composable (() -> Unit),
@@ -70,7 +68,6 @@ fun ProfileEditScreen(
         }
     }
     val pagerState = rememberPagerState(
-        initialPage = state.selectedTab.ordinal,
         pageCount = { ProfileEditTabs.entries.size },
     )
     val coroutineScope = rememberCoroutineScope()
@@ -113,19 +110,6 @@ fun ProfileEditScreen(
                         vertical = 16.dp,
                     ),
             ) {
-                LaunchedEffect(state.selectedTab) {
-                    if (pagerState.currentPage != state.selectedTab.ordinal) {
-                        pagerState.animateScrollToPage(state.selectedTab.ordinal)
-                    }
-                }
-
-                LaunchedEffect(pagerState.currentPage) {
-                    val newTab = ProfileEditTabs.entries[pagerState.currentPage]
-                    if (state.selectedTab != newTab) {
-                        onEvent(ProfileEditScreenEvent.SwitchTab(newTab))
-                    }
-                }
-
                 CoreTopTabs(
                     selectedIndex = pagerState.currentPage,
                     onSelected = { index ->
@@ -160,7 +144,7 @@ fun ProfileEditScreen(
         }
     }
 
-    if (showUnsavedChangesDialog) {
+    if (state.showUnsavedChangesDialog) {
         UnsavedChangesDialog(
             onLeave = { onEvent(ProfileEditScreenEvent.DiscardChanges) },
             onStay = { onEvent(ProfileEditScreenEvent.UnsavedChangesDialogDismissed) },
@@ -172,7 +156,6 @@ fun ProfileEditScreen(
 @Composable
 fun ProfileEditPreview() {
     val screenState = ProfileEditState.Loaded(
-        selectedTab = PersonalInfo,
         personalInfoState = ProfileEditState.PersonalInfoTabState(
             avatarUrl = null,
             nickname = ProfileEditState.ValidatedField(
@@ -206,20 +189,15 @@ fun ProfileEditPreview() {
             listOfSkills = persistentListOf(),
             listOfChosenSkills = persistentListOf(),
         ),
-        hasUnsavedChanges = true,
+        showUnsavedChangesDialog = false,
     )
 
     var state by remember { mutableStateOf(screenState) }
 
     ProfileEditScreen(
         state = state,
-        showUnsavedChangesDialog = false,
         onEvent = { event ->
             when (event) {
-                is ProfileEditScreenEvent.SwitchTab -> {
-                    state = state.copy(selectedTab = event.tab)
-                }
-
                 is ProfileEditScreenEvent.ChooseSpecialization -> {
                     state = state.copy(
                         personalInfoState = state.personalInfoState.copy(
@@ -227,7 +205,6 @@ fun ProfileEditPreview() {
                         ),
                     )
                 }
-
                 else -> {}
             }
         },
@@ -243,7 +220,6 @@ fun ProfileEditPreview() {
                                 ),
                             )
                         }
-
                         else -> {}
                     }
                 },
@@ -260,7 +236,6 @@ fun ProfileEditPreview() {
 @Composable
 fun ProfileEditWithDialogPreview() {
     val screenState = ProfileEditState.Loaded(
-        selectedTab = PersonalInfo,
         personalInfoState = ProfileEditState.PersonalInfoTabState(
             avatarUrl = null,
             nickname = ProfileEditState.ValidatedField("John Doe", null),
@@ -278,14 +253,13 @@ fun ProfileEditWithDialogPreview() {
             listOfSkills = persistentListOf(),
             listOfChosenSkills = persistentListOf(),
         ),
-        hasUnsavedChanges = true,
+        showUnsavedChangesDialog = true,
     )
 
     var state by remember { mutableStateOf(screenState) }
 
     ProfileEditScreen(
         state = state,
-        showUnsavedChangesDialog = true,
         onEvent = { },
         tabs = ProfileEditTabs.entries,
         headerText = TextOrResource.Text("Редактирование профиля"),

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/ProfileEditScreen.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/ProfileEditScreen.kt
@@ -34,6 +34,8 @@ import ru.yeahub.profile_edit.impl.presentation.ProfileEditState.ProfileEditTabs
 import ru.yeahub.profile_edit.impl.presentation.ProfileEditState.ProfileEditTabs.AboutMe
 import ru.yeahub.profile_edit.impl.presentation.ProfileEditState.ProfileEditTabs.PersonalInfo
 import ru.yeahub.profile_edit.impl.presentation.ProfileEditState.ProfileEditTabs.Skills
+import ru.yeahub.profile_edit.impl.presentation.ProfileEditState.SocialLinks
+import ru.yeahub.profile_edit.impl.ui.tabs.AboutMeContent
 import ru.yeahub.profile_edit.impl.ui.tabs.PersonalInfoContent
 import ru.yeahub.ui.R
 
@@ -145,13 +147,24 @@ fun ProfileEditPreview() {
         selectedTab = PersonalInfo,
         personalInfoState = ProfileEditState.PersonalInfoTabState(
             avatarUrl = null,
-            nickname = "John Doe",
+            nickname = ProfileEditState.ValidatedField(
+                value = "J",
+                error = TextOrResource.Resource(R.string.error_minimal_length_2),
+            ),
             specializationList = emptyList(),
-            specialization = "",
-            email = "johndoe@gmail.com",
-            location = "Санкт-Петербург",
-            socialLinksUrlMap = persistentMapOf(),
+            specialization = "Android разработчик",
             isSpecializationEditable = false,
+            email = "johndoe@gmail.com",
+            location = ProfileEditState.ValidatedField("Санкт-Петербург", null),
+            socialLinks = persistentMapOf(
+                Pair(
+                    SocialLinks.Linkedin,
+                    ProfileEditState.ValidatedField(
+                        "",
+                        TextOrResource.Resource(R.string.error_max_length_255),
+                    ),
+                ),
+            ),
         ),
         aboutMeTabState = ProfileEditState.AboutMeTabState(
             aboutMeField = "",
@@ -178,7 +191,7 @@ fun ProfileEditPreview() {
                 onEvent = { },
             )
         },
-        aboutMeContent = { },
+        aboutMeContent = { AboutMeContent(state.aboutMeTabState) },
         skillsContent = { },
         tabs = ProfileEditTabs.entries,
         headerText = TextOrResource.Text("Редактирование профиля"),
@@ -193,13 +206,13 @@ fun ProfileEditWithDialogPreview() {
         selectedTab = PersonalInfo,
         personalInfoState = ProfileEditState.PersonalInfoTabState(
             avatarUrl = null,
-            nickname = "John Doe",
+            nickname = ProfileEditState.ValidatedField("John Doe", null),
             specializationList = emptyList(),
             specialization = "Android Разработчик",
+            isSpecializationEditable = false,
             email = "johndoe@gmail.com",
-            location = "Санкт-Петербург",
-            socialLinksUrlMap = persistentMapOf(),
-            isSpecializationEditable = true,
+            location = ProfileEditState.ValidatedField("Санкт-Петербург", null),
+            socialLinks = persistentMapOf(),
         ),
         aboutMeTabState = ProfileEditState.AboutMeTabState(
             aboutMeField = "",

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/ProfileEditScreen.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/ProfileEditScreen.kt
@@ -1,5 +1,6 @@
 package ru.yeahub.profile_edit.impl.ui
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -23,6 +24,7 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
 import ru.yeahub.core_ui.component.CoreTopTabs
 import ru.yeahub.core_ui.component.TopAppBarWithBottomBorder
+import ru.yeahub.core_ui.component.UnsavedChangesDialog
 import ru.yeahub.core_ui.theme.Theme
 import ru.yeahub.core_utils.common.TextOrResource
 import ru.yeahub.profile_edit.impl.presentation.ProfileEditState
@@ -36,13 +38,19 @@ import ru.yeahub.profile_edit.impl.ui.tabs.PersonalInfoContent
 fun ProfileEditScreen(
     tabs: List<ProfileEditTabs>,
     state: ProfileEditState.Loaded,
+    showUnsavedChangesDialog: Boolean,
     onTabSelected: (ProfileEditTabs) -> Unit,
     onBackClick: () -> Unit,
+    onLeaveConfirmed: () -> Unit,
+    onLeaveDismissed: () -> Unit,
     headerText: TextOrResource,
     personalInfoContent: @Composable (() -> Unit),
     aboutMeContent: @Composable (() -> Unit),
     skillsContent: @Composable (() -> Unit),
 ) {
+    BackHandler {
+        onBackClick()
+    }
     val tabTitles = remember(tabs) {
         tabs.map { tab ->
             when (tab) {
@@ -107,6 +115,13 @@ fun ProfileEditScreen(
             }
         }
     }
+
+    if (showUnsavedChangesDialog) {
+        UnsavedChangesDialog(
+            onLeave = onLeaveConfirmed,
+            onStay = onLeaveDismissed,
+        )
+    }
 }
 
 @Preview
@@ -130,14 +145,18 @@ fun ProfileEditPreview() {
             listOfSkills = persistentListOf(),
             listOfChosenSkills = persistentListOf(),
         ),
+        hasUnsavedChanges = true,
     )
 
     var state by remember { mutableStateOf(screenState) }
 
     ProfileEditScreen(
         state = state,
+        showUnsavedChangesDialog = false,
         onTabSelected = { state = state.copy(selectedTab = it) },
         onBackClick = {},
+        onLeaveConfirmed = {},
+        onLeaveDismissed = {},
         personalInfoContent = {
             PersonalInfoContent(
                 state = state.personalInfoState,
@@ -148,5 +167,51 @@ fun ProfileEditPreview() {
         skillsContent = { },
         tabs = ProfileEditTabs.entries,
         headerText = TextOrResource.Text("Редактирование профиля"),
+    )
+}
+
+@Preview
+@Composable
+fun ProfileEditWithDialogPreview() {
+    val screenState = ProfileEditState.Loaded(
+        selectedTab = PersonalInfo,
+        personalInfoState = ProfileEditState.PersonalInfoTabState(
+            avatarUrl = null,
+            nickname = "John Doe",
+            specializationList = emptyList(),
+            specialization = "Android Разработчик",
+            email = "johndoe@gmail.com",
+            location = "Санкт-Петербург",
+            socialLinksUrlMap = persistentMapOf(),
+        ),
+        aboutMeTabState = ProfileEditState.AboutMeTabState(
+            aboutMeField = "",
+        ),
+        skillsTabState = ProfileEditState.SkillsTabState(
+            listOfSkills = persistentListOf(),
+            listOfChosenSkills = persistentListOf(),
+        ),
+        hasUnsavedChanges = true,
+    )
+
+    var state by remember { mutableStateOf(screenState) }
+
+    ProfileEditScreen(
+        state = state,
+        showUnsavedChangesDialog = true,
+        onTabSelected = {},
+        onBackClick = {},
+        onLeaveConfirmed = {},
+        onLeaveDismissed = {},
+        tabs = ProfileEditTabs.entries,
+        headerText = TextOrResource.Text("Редактирование профиля"),
+        personalInfoContent = {
+            PersonalInfoContent(
+                state = state.personalInfoState,
+                onEvent = { },
+            )
+        },
+        aboutMeContent = {},
+        skillsContent = {},
     )
 }

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/ProfileEditScreen.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/ProfileEditScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -149,11 +150,13 @@ fun ProfileEditScreen(
                         .fillMaxWidth()
                         .background(Theme.colors.white900),
                 ) { page ->
-                    Box(modifier = Modifier.fillMaxSize()) {
-                        when (ProfileEditTabs.entries[page]) {
-                            PersonalInfo -> personalInfoContent()
-                            AboutMe -> aboutMeContent()
-                            Skills -> skillsContent()
+                    key(page) {
+                        Box(modifier = Modifier.fillMaxSize()) {
+                            when (ProfileEditTabs.entries[page]) {
+                                PersonalInfo -> personalInfoContent()
+                                AboutMe -> aboutMeContent()
+                                Skills -> skillsContent()
+                            }
                         }
                     }
                 }

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/ProfileEditScreen.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/ProfileEditScreen.kt
@@ -151,6 +151,7 @@ fun ProfileEditPreview() {
             email = "johndoe@gmail.com",
             location = "Санкт-Петербург",
             socialLinksUrlMap = persistentMapOf(),
+            isSpecializationEditable = false,
         ),
         aboutMeTabState = ProfileEditState.AboutMeTabState(
             aboutMeField = "",
@@ -198,6 +199,7 @@ fun ProfileEditWithDialogPreview() {
             email = "johndoe@gmail.com",
             location = "Санкт-Петербург",
             socialLinksUrlMap = persistentMapOf(),
+            isSpecializationEditable = true,
         ),
         aboutMeTabState = ProfileEditState.AboutMeTabState(
             aboutMeField = "",

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/ProfileEditScreen.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/ProfileEditScreen.kt
@@ -35,6 +35,7 @@ import ru.yeahub.profile_edit.impl.presentation.ProfileEditState.ProfileEditTabs
 import ru.yeahub.profile_edit.impl.presentation.ProfileEditState.ProfileEditTabs.PersonalInfo
 import ru.yeahub.profile_edit.impl.presentation.ProfileEditState.ProfileEditTabs.Skills
 import ru.yeahub.profile_edit.impl.presentation.ProfileEditState.SocialLinks
+import ru.yeahub.profile_edit.impl.presentation.intents.ProfileEditScreenEvent
 import ru.yeahub.profile_edit.impl.ui.tabs.AboutMeContent
 import ru.yeahub.profile_edit.impl.ui.tabs.PersonalInfoContent
 import ru.yeahub.ui.R
@@ -151,9 +152,14 @@ fun ProfileEditPreview() {
                 value = "J",
                 error = TextOrResource.Resource(R.string.error_minimal_length_2),
             ),
-            specializationList = emptyList(),
-            specialization = "Android разработчик",
-            isSpecializationEditable = false,
+            specializationList = listOf(
+                "Android разработчик",
+                "iOS разработчик",
+                "Backend разработчик",
+                "Frontend разработчик",
+            ),
+            specialization = "",
+            isSpecializationEditable = true,
             email = "johndoe@gmail.com",
             location = ProfileEditState.ValidatedField("Санкт-Петербург", null),
             socialLinks = persistentMapOf(
@@ -188,7 +194,19 @@ fun ProfileEditPreview() {
         personalInfoContent = {
             PersonalInfoContent(
                 state = state.personalInfoState,
-                onEvent = { },
+                onEvent = { event ->
+                    when (event) {
+                        is ProfileEditScreenEvent.ChooseSpecialization -> {
+                            state = state.copy(
+                                personalInfoState = state.personalInfoState.copy(
+                                    specialization = event.specialization,
+                                ),
+                            )
+                        }
+
+                        else -> {}
+                    }
+                },
             )
         },
         aboutMeContent = { AboutMeContent(state.aboutMeTabState) },

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/ProfileEditScreen.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/ProfileEditScreen.kt
@@ -133,7 +133,7 @@ fun ProfileEditPreview() {
             avatarUrl = null,
             nickname = "John Doe",
             specializationList = emptyList(),
-            specialization = "Android Разработчик",
+            specialization = "",
             email = "johndoe@gmail.com",
             location = "Санкт-Петербург",
             socialLinksUrlMap = persistentMapOf(),

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/ProfileEditScreen.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/ProfileEditScreen.kt
@@ -8,14 +8,18 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -23,6 +27,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.coroutines.launch
 import ru.yeahub.core_ui.component.CoreTopTabs
 import ru.yeahub.core_ui.component.PrimaryButton
 import ru.yeahub.core_ui.component.TopAppBarWithBottomBorder
@@ -67,6 +72,12 @@ fun ProfileEditScreen(
             }
         }
     }
+    val pagerState = rememberPagerState(
+        initialPage = state.selectedTab.ordinal,
+        pageCount = { ProfileEditTabs.entries.size },
+    )
+    val coroutineScope = rememberCoroutineScope()
+
 
     Scaffold(
         containerColor = Theme.colors.black10,
@@ -106,10 +117,24 @@ fun ProfileEditScreen(
                         vertical = 16.dp,
                     ),
             ) {
+
+                LaunchedEffect(state.selectedTab) {
+                    if (pagerState.currentPage != state.selectedTab.ordinal) {
+                        pagerState.animateScrollToPage(state.selectedTab.ordinal)
+                    }
+                }
+
+                LaunchedEffect(pagerState.currentPage) {
+                    val newTab = ProfileEditTabs.entries[pagerState.currentPage]
+                    if (state.selectedTab != newTab) {
+                        onTabSelected(newTab)
+                    }
+                }
+
                 CoreTopTabs(
-                    selectedIndex = state.selectedTab.ordinal,
+                    selectedIndex = pagerState.currentPage,
                     onSelected = { index ->
-                        onTabSelected(ProfileEditTabs.entries[index])
+                        coroutineScope.launch { pagerState.animateScrollToPage(index) }
                     },
                     modifier = Modifier
                         .fillMaxWidth()
@@ -118,15 +143,20 @@ fun ProfileEditScreen(
                     edgePadding = (-16).dp,
                     indicatorHeight = 10.dp,
                 )
-                Box(
+
+                HorizontalPager(
+                    state = pagerState,
                     modifier = Modifier
+                        .weight(1f)
                         .fillMaxWidth()
                         .background(Theme.colors.white900),
-                ) {
-                    when (state.selectedTab) {
-                        PersonalInfo -> personalInfoContent()
-                        AboutMe -> aboutMeContent()
-                        Skills -> skillsContent()
+                ) { page ->
+                    Box(modifier = Modifier.fillMaxSize()) {
+                        when (ProfileEditTabs.entries[page]) {
+                            PersonalInfo -> personalInfoContent()
+                            AboutMe -> aboutMeContent()
+                            Skills -> skillsContent()
+                        }
                     }
                 }
             }
@@ -203,7 +233,6 @@ fun ProfileEditPreview() {
                                 ),
                             )
                         }
-
                         else -> {}
                     }
                 },

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/ProfileEditScreen.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/ProfileEditScreen.kt
@@ -51,18 +51,14 @@ fun ProfileEditScreen(
     tabs: List<ProfileEditTabs>,
     state: ProfileEditState.Loaded,
     showUnsavedChangesDialog: Boolean,
-    onTabSelected: (ProfileEditTabs) -> Unit,
-    onBackClick: () -> Unit,
-    onSaveClick: () -> Unit,
-    onLeaveConfirmed: () -> Unit,
-    onLeaveDismissed: () -> Unit,
+    onEvent: (ProfileEditScreenEvent) -> Unit,
     headerText: TextOrResource,
     personalInfoContent: @Composable (() -> Unit),
     aboutMeContent: @Composable (() -> Unit),
     skillsContent: @Composable (() -> Unit),
 ) {
     BackHandler {
-        onBackClick()
+        onEvent(ProfileEditScreenEvent.BackPressed)
     }
     val tabTitles = remember(tabs) {
         tabs.map { tab ->
@@ -84,12 +80,12 @@ fun ProfileEditScreen(
         topBar = {
             TopAppBarWithBottomBorder(
                 title = headerText,
-                onBackClick = onBackClick,
+                onBackClick = { onEvent(ProfileEditScreenEvent.BackPressed) },
             )
         },
         bottomBar = {
             PrimaryButton(
-                onClick = onSaveClick,
+                onClick = { onEvent(ProfileEditScreenEvent.SaveProfile) },
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 16.dp),
@@ -126,7 +122,7 @@ fun ProfileEditScreen(
                 LaunchedEffect(pagerState.currentPage) {
                     val newTab = ProfileEditTabs.entries[pagerState.currentPage]
                     if (state.selectedTab != newTab) {
-                        onTabSelected(newTab)
+                        onEvent(ProfileEditScreenEvent.SwitchTab(newTab))
                     }
                 }
 
@@ -166,8 +162,8 @@ fun ProfileEditScreen(
 
     if (showUnsavedChangesDialog) {
         UnsavedChangesDialog(
-            onLeave = onLeaveConfirmed,
-            onStay = onLeaveDismissed,
+            onLeave = { onEvent(ProfileEditScreenEvent.DiscardChanges) },
+            onStay = { onEvent(ProfileEditScreenEvent.UnsavedChangesDialogDismissed) },
         )
     }
 }
@@ -218,10 +214,23 @@ fun ProfileEditPreview() {
     ProfileEditScreen(
         state = state,
         showUnsavedChangesDialog = false,
-        onTabSelected = { state = state.copy(selectedTab = it) },
-        onBackClick = {},
-        onLeaveConfirmed = {},
-        onLeaveDismissed = {},
+        onEvent = { event ->
+            when (event) {
+                is ProfileEditScreenEvent.SwitchTab -> {
+                    state = state.copy(selectedTab = event.tab)
+                }
+
+                is ProfileEditScreenEvent.ChooseSpecialization -> {
+                    state = state.copy(
+                        personalInfoState = state.personalInfoState.copy(
+                            specialization = event.specialization,
+                        ),
+                    )
+                }
+
+                else -> {}
+            }
+        },
         personalInfoContent = {
             PersonalInfoContent(
                 state = state.personalInfoState,
@@ -234,6 +243,7 @@ fun ProfileEditPreview() {
                                 ),
                             )
                         }
+
                         else -> {}
                     }
                 },
@@ -243,7 +253,6 @@ fun ProfileEditPreview() {
         skillsContent = { },
         tabs = ProfileEditTabs.entries,
         headerText = TextOrResource.Text("Редактирование профиля"),
-        onSaveClick = { },
     )
 }
 
@@ -277,10 +286,7 @@ fun ProfileEditWithDialogPreview() {
     ProfileEditScreen(
         state = state,
         showUnsavedChangesDialog = true,
-        onTabSelected = {},
-        onBackClick = {},
-        onLeaveConfirmed = {},
-        onLeaveDismissed = {},
+        onEvent = { },
         tabs = ProfileEditTabs.entries,
         headerText = TextOrResource.Text("Редактирование профиля"),
         personalInfoContent = {
@@ -291,6 +297,5 @@ fun ProfileEditWithDialogPreview() {
         },
         aboutMeContent = {},
         skillsContent = {},
-        onSaveClick = { },
     )
 }

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/ProfileEditScreen.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/ProfileEditScreen.kt
@@ -183,7 +183,7 @@ fun ProfileEditPreview() {
                 value = "J",
                 error = TextOrResource.Resource(R.string.error_minimal_length_2),
             ),
-            specializationList = listOf(
+            specializationList = persistentListOf(
                 "Android разработчик",
                 "iOS разработчик",
                 "Backend разработчик",
@@ -255,7 +255,7 @@ fun ProfileEditWithDialogPreview() {
         personalInfoState = ProfileEditState.PersonalInfoTabState(
             avatarUrl = null,
             nickname = ProfileEditState.ValidatedField("John Doe", null),
-            specializationList = emptyList(),
+            specializationList = persistentListOf(),
             specialization = "Android Разработчик",
             isSpecializationEditable = false,
             email = "johndoe@gmail.com",

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/ProfileEditScreen.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/ProfileEditScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -23,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
 import ru.yeahub.core_ui.component.CoreTopTabs
+import ru.yeahub.core_ui.component.PrimaryButton
 import ru.yeahub.core_ui.component.TopAppBarWithBottomBorder
 import ru.yeahub.core_ui.component.UnsavedChangesDialog
 import ru.yeahub.core_ui.theme.Theme
@@ -33,6 +35,7 @@ import ru.yeahub.profile_edit.impl.presentation.ProfileEditState.ProfileEditTabs
 import ru.yeahub.profile_edit.impl.presentation.ProfileEditState.ProfileEditTabs.PersonalInfo
 import ru.yeahub.profile_edit.impl.presentation.ProfileEditState.ProfileEditTabs.Skills
 import ru.yeahub.profile_edit.impl.ui.tabs.PersonalInfoContent
+import ru.yeahub.ui.R
 
 @Composable
 fun ProfileEditScreen(
@@ -41,6 +44,7 @@ fun ProfileEditScreen(
     showUnsavedChangesDialog: Boolean,
     onTabSelected: (ProfileEditTabs) -> Unit,
     onBackClick: () -> Unit,
+    onSaveClick: () -> Unit,
     onLeaveConfirmed: () -> Unit,
     onLeaveDismissed: () -> Unit,
     headerText: TextOrResource,
@@ -54,9 +58,9 @@ fun ProfileEditScreen(
     val tabTitles = remember(tabs) {
         tabs.map { tab ->
             when (tab) {
-                PersonalInfo -> ru.yeahub.ui.R.string.profile_personal_information
-                AboutMe -> ru.yeahub.ui.R.string.profile_about_me
-                Skills -> ru.yeahub.ui.R.string.profile_skills
+                PersonalInfo -> R.string.profile_personal_information
+                AboutMe -> R.string.profile_about_me
+                Skills -> R.string.profile_skills
             }
         }
     }
@@ -69,6 +73,16 @@ fun ProfileEditScreen(
                 onBackClick = onBackClick,
             )
         },
+        bottomBar = {
+            PrimaryButton(
+                onClick = onSaveClick,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+            ) {
+                Text(text = stringResource(R.string.save))
+            }
+        },
     ) { paddingValues ->
 
         Surface(
@@ -77,7 +91,7 @@ fun ProfileEditScreen(
                 .padding(paddingValues)
                 .padding(horizontal = 16.dp)
                 .padding(top = 16.dp)
-                .padding(bottom = 16.dp),
+                .padding(bottom = 0.dp),
             color = Theme.colors.white900,
             shape = RoundedCornerShape(16.dp),
         ) {
@@ -167,6 +181,7 @@ fun ProfileEditPreview() {
         skillsContent = { },
         tabs = ProfileEditTabs.entries,
         headerText = TextOrResource.Text("Редактирование профиля"),
+        onSaveClick = { },
     )
 }
 
@@ -213,5 +228,6 @@ fun ProfileEditWithDialogPreview() {
         },
         aboutMeContent = {},
         skillsContent = {},
+        onSaveClick = { },
     )
 }

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/tabs/ProfileEditPersonalInfoTab.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/tabs/ProfileEditPersonalInfoTab.kt
@@ -134,6 +134,7 @@ fun PersonalInfoContent(
                             .height(20.dp),
                     )
                 },
+                isEnabled = state.isSpecializationEditable,
             )
             TextButton(
                 onClick = { onEvent(ProfileEditScreenEvent.CannotChangeSpecializationToast) },
@@ -282,6 +283,7 @@ fun ProfileEditPersonalInfoPreview() {
         email = "johndoe@gmail.com",
         location = "Санкт-Петербург",
         socialLinksUrlMap = persistentMapOf(),
+        isSpecializationEditable = false,
     )
     PersonalInfoContent(state = personalInfoState, onEvent = {})
 }

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/tabs/ProfileEditPersonalInfoTab.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/tabs/ProfileEditPersonalInfoTab.kt
@@ -80,13 +80,13 @@ fun PersonalInfoContent(
         item {
             ProfileAvatarSection(
                 avatarUrl = state.avatarUrl,
-                onRemoveClick = { onEvent(ProfileEditScreenEvent.ToDo) },
+                onRemoveClick = { onEvent(ProfileEditScreenEvent.DeleteAvatar) },
             )
             Spacer(Modifier.height(AVATAR_BOTTOM_SPACER))
         }
         item {
             UploadPhotoButton(
-                onClick = { onEvent(ProfileEditScreenEvent.ToDo) },
+                onClick = { onEvent(ProfileEditScreenEvent.UploadAvatar) },
             )
             Spacer(Modifier.height(UPLOAD_BUTTON_BOTTOM_SPACER))
         }
@@ -104,7 +104,7 @@ fun PersonalInfoContent(
             FieldLabel(text = stringResource(R.string.profile_nickname_label))
             DefaultTextField(
                 value = state.nickname,
-                onValueChange = { onEvent(ProfileEditScreenEvent.ToDo) },
+                onValueChange = { onEvent(ProfileEditScreenEvent.OnNicknameChanged(it)) },
                 placeholder = stringResource(R.string.profile_nickname_placeholder),
                 modifier = Modifier
                     .fillMaxWidth()
@@ -116,10 +116,10 @@ fun PersonalInfoContent(
         item {
             FieldLabel(text = stringResource(R.string.profile_specialization_label))
             DropDownMenu(
-                placeholder = stringResource(R.string.profile_nickname_placeholder),
+                placeholder = stringResource(R.string.profile_specialization_label),
                 items = state.specializationList,
                 selected = state.specialization,
-                onSelected = { onEvent(ProfileEditScreenEvent.ToDo) },
+                onSelected = { onEvent(ProfileEditScreenEvent.ChooseSpecialization(it)) },
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(TEXT_FIELD_HEIGHT),
@@ -144,7 +144,7 @@ fun PersonalInfoContent(
             FieldLabel(text = stringResource(R.string.profile_location_label))
             DefaultTextField(
                 value = state.location,
-                onValueChange = { onEvent(ProfileEditScreenEvent.ToDo) },
+                onValueChange = { onEvent(ProfileEditScreenEvent.OnLocationChanged(it)) },
                 placeholder = stringResource(R.string.profile_location_placeholder),
                 modifier = Modifier
                     .fillMaxWidth()
@@ -168,7 +168,14 @@ fun PersonalInfoContent(
                 SocialLinkField(
                     platform = platform,
                     value = state.socialLinksUrlMap[platform].orEmpty(),
-                    onValueChange = { onEvent(ProfileEditScreenEvent.ToDo) },
+                    onValueChange = {
+                        onEvent(
+                            ProfileEditScreenEvent.OnSocialLinkChanged(
+                                link = platform,
+                                url = it,
+                            ),
+                        )
+                    },
                 )
             }
         }

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/tabs/ProfileEditPersonalInfoTab.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/tabs/ProfileEditPersonalInfoTab.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentMapOf
 import ru.yeahub.core_ui.component.DropDownMenu
 import ru.yeahub.core_ui.component.UploadPhotoButton
@@ -302,7 +303,7 @@ fun ProfileEditPersonalInfoPreview() {
     val personalInfoState = ProfileEditState.PersonalInfoTabState(
         avatarUrl = null,
         nickname = ProfileEditState.ValidatedField("John Doe", null),
-        specializationList = emptyList(),
+        specializationList = persistentListOf(),
         specialization = "Android Разработчик",
         isSpecializationEditable = false,
         email = "johndoe@gmail.com",

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/tabs/ProfileEditPersonalInfoTab.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/tabs/ProfileEditPersonalInfoTab.kt
@@ -36,12 +36,11 @@ import ru.yeahub.profile_edit.impl.ui.FieldLabel
 import ru.yeahub.profile_edit.impl.ui.SectionTitle
 import ru.yeahub.ui.R
 
-private val PERSONAL_INFO_TOP_PADDING = 2.dp
-private val PERSONAL_INFO_TOP_SPACER = 10.dp
+private val PHOTO_SECTION_TOP_SPACER = 23.dp
 
 private val SECTION_TITLE_BOTTOM_SPACER = 6.dp
-private val PROFILE_DESCRIPTION_BOTTOM_SPACER = 16.dp
-private val AVATAR_BOTTOM_SPACER = 16.dp
+private val PROFILE_DESCRIPTION_BOTTOM_SPACER = 18.dp
+private val AVATAR_BOTTOM_SPACER = 18.dp
 private val UPLOAD_BUTTON_BOTTOM_SPACER = 24.dp
 
 private val SECTION_SUBTITLE_BOTTOM_SPACER = 12.dp
@@ -66,11 +65,10 @@ fun PersonalInfoContent(
     LazyColumn(
         modifier = Modifier
             .fillMaxWidth()
-            .background(Theme.colors.white900)
-            .padding(top = PERSONAL_INFO_TOP_PADDING),
+            .background(Theme.colors.white900),
     ) {
         item {
-            Spacer(Modifier.padding(PERSONAL_INFO_TOP_SPACER))
+            Spacer(Modifier.height(PHOTO_SECTION_TOP_SPACER))
             SectionTitle(title = stringResource(R.string.profile_photo))
         }
         item {

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/tabs/ProfileEditPersonalInfoTab.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/tabs/ProfileEditPersonalInfoTab.kt
@@ -111,7 +111,7 @@ fun PersonalInfoContent(
             FieldLabel(text = stringResource(R.string.profile_nickname_label))
             ValidatedTextField(
                 field = state.nickname,
-                onValueChange = { onEvent(ProfileEditScreenEvent.OnNicknameChanged(it)) },
+                onValueChange = { onEvent(ProfileEditScreenEvent.NicknameChanged(it)) },
                 placeholder = stringResource(R.string.profile_nickname_placeholder),
             )
         }
@@ -166,7 +166,7 @@ fun PersonalInfoContent(
             FieldLabel(text = stringResource(R.string.profile_location_label))
             ValidatedTextField(
                 field = state.location,
-                onValueChange = { onEvent(ProfileEditScreenEvent.OnLocationChanged(it)) },
+                onValueChange = { onEvent(ProfileEditScreenEvent.LocationChanged(it)) },
                 placeholder = stringResource(R.string.profile_location_placeholder),
             )
             Spacer(Modifier.height(LINKS_SECTION_TOP_SPACER))
@@ -189,7 +189,7 @@ fun PersonalInfoContent(
                         ?: ProfileEditState.ValidatedField("", null),
                     onValueChange = {
                         onEvent(
-                            ProfileEditScreenEvent.OnSocialLinkChanged(
+                            ProfileEditScreenEvent.SocialLinkChanged(
                                 link = platform,
                                 url = it,
                             ),

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/tabs/ProfileEditPersonalInfoTab.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/tabs/ProfileEditPersonalInfoTab.kt
@@ -45,7 +45,7 @@ private val AVATAR_BOTTOM_SPACER = 18.dp
 private val UPLOAD_BUTTON_BOTTOM_SPACER = 24.dp
 
 private val SECTION_SUBTITLE_BOTTOM_SPACER = 12.dp
-private val FIELD_BOTTOM_SPACER = 12.dp
+private val NICKNAME_AND_SPECIALIZATION_FIELD_BOTTOM_SPACER = 12.dp
 private val LINKS_SECTION_TOP_SPACER = 8.dp
 private val SPECIALIZATION_SPACER = 8.dp
 private val LINKS_SECTION_TITLE_BOTTOM_SPACER = 6.dp
@@ -56,7 +56,7 @@ private val AVATAR_HEIGHT = 263.dp
 private val AVATAR_WIDTH = 326.dp
 private val REMOVE_PHOTO_BUTTON_HEIGHT = 25.dp
 private val REMOVE_PHOTO_BUTTON_PADDING = 8.dp
-private val VALIDATION_ERROR_HEIGHT = 16.dp
+private val VALIDATION_FIELD_BOTTOM_SPACER = 16.dp
 
 @Composable
 fun PersonalInfoContent(
@@ -145,7 +145,7 @@ fun PersonalInfoContent(
                     onEvent(ProfileEditScreenEvent.CannotChangeSpecializationToast)
                 },
             )
-            Spacer(Modifier.height(FIELD_BOTTOM_SPACER))
+            Spacer(Modifier.height(NICKNAME_AND_SPECIALIZATION_FIELD_BOTTOM_SPACER))
         }
         item {
             FieldLabel(text = stringResource(R.string.profile_email_label))
@@ -160,7 +160,7 @@ fun PersonalInfoContent(
                 readOnly = true,
                 isEnabled = false,
             )
-            Spacer(Modifier.height(FIELD_BOTTOM_SPACER))
+            Spacer(Modifier.height(NICKNAME_AND_SPECIALIZATION_FIELD_BOTTOM_SPACER))
         }
         item {
             FieldLabel(text = stringResource(R.string.profile_location_label))
@@ -281,20 +281,20 @@ private fun ValidatedTextField(
         onExpandedChange = {},
         isError = field.error != null,
     )
-    ValidationErrorText(error = field.error)
+    Box(modifier = Modifier.height(VALIDATION_FIELD_BOTTOM_SPACER)) {
+        if (field.error != null) {
+            ValidationErrorText(error = field.error)
+        }
+    }
 }
 
 @Composable
-private fun ValidationErrorText(error: TextOrResource?) {
-    Box(modifier = Modifier.height(VALIDATION_ERROR_HEIGHT)) {
-        error?.let {
-            Text(
-                text = it.getString(LocalContext.current),
-                style = Theme.typography.body7Alt,
-                color = Theme.colors.red700,
-            )
-        }
-    }
+private fun ValidationErrorText(error: TextOrResource) {
+    Text(
+        text = error.getString(LocalContext.current),
+        style = Theme.typography.body7Alt,
+        color = Theme.colors.red700,
+    )
 }
 
 @Preview(showBackground = true)

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/tabs/ProfileEditPersonalInfoTab.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/tabs/ProfileEditPersonalInfoTab.kt
@@ -2,9 +2,9 @@ package ru.yeahub.profile_edit.impl.ui.tabs
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -42,19 +41,21 @@ private val PERSONAL_INFO_TOP_SPACER = 10.dp
 
 private val SECTION_TITLE_BOTTOM_SPACER = 6.dp
 private val PROFILE_DESCRIPTION_BOTTOM_SPACER = 16.dp
-private val AVATAR_BOTTOM_SPACER = 12.dp
+private val AVATAR_BOTTOM_SPACER = 16.dp
 private val UPLOAD_BUTTON_BOTTOM_SPACER = 24.dp
 
 private val SECTION_SUBTITLE_BOTTOM_SPACER = 12.dp
 private val FIELD_BOTTOM_SPACER = 12.dp
 private val LINKS_SECTION_TOP_SPACER = 8.dp
+private val SPECIALIZATION_SPACER = 8.dp
 private val LINKS_SECTION_TITLE_BOTTOM_SPACER = 6.dp
 private val SOCIAL_LINK_VERTICAL_PADDING = 4.dp
 
 private val TEXT_FIELD_HEIGHT = 52.dp
 private val AVATAR_HEIGHT = 263.dp
 private val AVATAR_WIDTH = 326.dp
-private val REMOVE_PHOTO_BUTTON_HEIGHT = 30.dp
+private val REMOVE_PHOTO_BUTTON_HEIGHT = 25.dp
+private val REMOVE_PHOTO_BUTTON_PADDING = 8.dp
 private val VALIDATION_ERROR_HEIGHT = 16.dp
 
 @Composable
@@ -136,16 +137,16 @@ fun PersonalInfoContent(
                 },
                 isEnabled = state.isSpecializationEditable,
             )
-            TextButton(
-                onClick = { onEvent(ProfileEditScreenEvent.CannotChangeSpecializationToast) },
-                contentPadding = PaddingValues(0.dp),
-            ) {
-                Text(
-                    text = stringResource(R.string.profile_change_specialization),
-                    style = Theme.typography.head7,
-                    color = Theme.colors.purple700,
-                )
-            }
+            Spacer(Modifier.height(SPECIALIZATION_SPACER))
+            Text(
+                text = stringResource(R.string.profile_change_specialization),
+                style = Theme.typography.head7,
+                color = Theme.colors.purple700,
+                modifier = Modifier.clickable {
+                    onEvent(ProfileEditScreenEvent.CannotChangeSpecializationToast)
+                },
+            )
+            Spacer(Modifier.height(FIELD_BOTTOM_SPACER))
         }
         item {
             FieldLabel(text = stringResource(R.string.profile_email_label))
@@ -230,16 +231,15 @@ private fun ProfileAvatarSection(
                 contentScale = ContentScale.Crop,
             )
         }
-        TextButton(
-            onClick = onRemoveClick,
-            modifier = Modifier.height(REMOVE_PHOTO_BUTTON_HEIGHT),
-        ) {
-            Text(
-                text = stringResource(R.string.profile_remove_photo),
-                style = Theme.typography.body7Alt,
-                color = Theme.colors.red700,
-            )
-        }
+        Text(
+            text = stringResource(R.string.profile_remove_photo),
+            style = Theme.typography.body7Alt,
+            color = Theme.colors.red700,
+            modifier = Modifier
+                .height(REMOVE_PHOTO_BUTTON_HEIGHT)
+                .padding(top = REMOVE_PHOTO_BUTTON_PADDING)
+                .clickable(onClick = onRemoveClick),
+        )
     }
 }
 

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/tabs/ProfileEditPersonalInfoTab.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/tabs/ProfileEditPersonalInfoTab.kt
@@ -3,7 +3,6 @@ package ru.yeahub.profile_edit.impl.ui.tabs
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -17,7 +16,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -35,28 +33,25 @@ import ru.yeahub.profile_edit.impl.presentation.ProfileEditState.SocialLinks
 import ru.yeahub.profile_edit.impl.presentation.intents.ProfileEditScreenEvent
 import ru.yeahub.profile_edit.impl.ui.FieldLabel
 import ru.yeahub.profile_edit.impl.ui.SectionTitle
+import ru.yeahub.profile_edit.impl.ui.ValidatedTextField
 import ru.yeahub.ui.R
 
 private val PHOTO_SECTION_TOP_SPACER = 23.dp
-
 private val SECTION_TITLE_BOTTOM_SPACER = 6.dp
 private val PROFILE_DESCRIPTION_BOTTOM_SPACER = 18.dp
 private val AVATAR_BOTTOM_SPACER = 18.dp
 private val UPLOAD_BUTTON_BOTTOM_SPACER = 24.dp
-
 private val SECTION_SUBTITLE_BOTTOM_SPACER = 12.dp
 private val NICKNAME_AND_SPECIALIZATION_FIELD_BOTTOM_SPACER = 12.dp
 private val LINKS_SECTION_TOP_SPACER = 8.dp
 private val SPECIALIZATION_SPACER = 8.dp
 private val LINKS_SECTION_TITLE_BOTTOM_SPACER = 6.dp
 private val SOCIAL_LINK_VERTICAL_PADDING = 4.dp
-
 private val TEXT_FIELD_HEIGHT = 52.dp
 private val AVATAR_HEIGHT = 263.dp
 private val AVATAR_WIDTH = 326.dp
 private val REMOVE_PHOTO_BUTTON_HEIGHT = 25.dp
 private val REMOVE_PHOTO_BUTTON_PADDING = 8.dp
-private val VALIDATION_FIELD_BOTTOM_SPACER = 16.dp
 
 @Composable
 fun PersonalInfoContent(
@@ -262,39 +257,6 @@ private fun SocialLinkField(
             placeholder = stringResource(R.string.profile_link_placeholder),
         )
     }
-}
-
-@Composable
-private fun ValidatedTextField(
-    field: ProfileEditState.ValidatedField,
-    onValueChange: (String) -> Unit,
-    placeholder: String,
-    modifier: Modifier = Modifier,
-) {
-    DefaultTextField(
-        value = field.value,
-        onValueChange = onValueChange,
-        placeholder = placeholder,
-        modifier = modifier
-            .fillMaxWidth()
-            .height(TEXT_FIELD_HEIGHT),
-        onExpandedChange = {},
-        isError = field.error != null,
-    )
-    Box(modifier = Modifier.height(VALIDATION_FIELD_BOTTOM_SPACER)) {
-        if (field.error != null) {
-            ValidationErrorText(error = field.error)
-        }
-    }
-}
-
-@Composable
-private fun ValidationErrorText(error: TextOrResource) {
-    Text(
-        text = error.getString(LocalContext.current),
-        style = Theme.typography.body7Alt,
-        color = Theme.colors.red700,
-    )
 }
 
 @Preview(showBackground = true)

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/tabs/ProfileEditPersonalInfoTab.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/tabs/ProfileEditPersonalInfoTab.kt
@@ -2,6 +2,7 @@ package ru.yeahub.profile_edit.impl.ui.tabs
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -17,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -27,7 +29,9 @@ import ru.yeahub.core_ui.component.DropDownMenu
 import ru.yeahub.core_ui.component.UploadPhotoButton
 import ru.yeahub.core_ui.component.textInput.DefaultTextField
 import ru.yeahub.core_ui.theme.Theme
+import ru.yeahub.core_utils.common.TextOrResource
 import ru.yeahub.profile_edit.impl.presentation.ProfileEditState
+import ru.yeahub.profile_edit.impl.presentation.ProfileEditState.SocialLinks
 import ru.yeahub.profile_edit.impl.presentation.intents.ProfileEditScreenEvent
 import ru.yeahub.profile_edit.impl.ui.FieldLabel
 import ru.yeahub.profile_edit.impl.ui.SectionTitle
@@ -43,7 +47,7 @@ private val UPLOAD_BUTTON_BOTTOM_SPACER = 24.dp
 
 private val SECTION_SUBTITLE_BOTTOM_SPACER = 12.dp
 private val FIELD_BOTTOM_SPACER = 12.dp
-private val LINKS_SECTION_TOP_SPACER = 24.dp
+private val LINKS_SECTION_TOP_SPACER = 8.dp
 private val LINKS_SECTION_TITLE_BOTTOM_SPACER = 6.dp
 private val SOCIAL_LINK_VERTICAL_PADDING = 4.dp
 
@@ -51,6 +55,7 @@ private val TEXT_FIELD_HEIGHT = 52.dp
 private val AVATAR_HEIGHT = 263.dp
 private val AVATAR_WIDTH = 326.dp
 private val REMOVE_PHOTO_BUTTON_HEIGHT = 30.dp
+private val VALIDATION_ERROR_HEIGHT = 16.dp
 
 @Composable
 fun PersonalInfoContent(
@@ -104,16 +109,11 @@ fun PersonalInfoContent(
         }
         item {
             FieldLabel(text = stringResource(R.string.profile_nickname_label))
-            DefaultTextField(
-                value = state.nickname,
+            ValidatedTextField(
+                field = state.nickname,
                 onValueChange = { onEvent(ProfileEditScreenEvent.OnNicknameChanged(it)) },
                 placeholder = stringResource(R.string.profile_nickname_placeholder),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(TEXT_FIELD_HEIGHT),
-                onExpandedChange = {},
             )
-            Spacer(Modifier.height(FIELD_BOTTOM_SPACER))
         }
         item {
             FieldLabel(text = stringResource(R.string.profile_specialization_label))
@@ -164,14 +164,10 @@ fun PersonalInfoContent(
         }
         item {
             FieldLabel(text = stringResource(R.string.profile_location_label))
-            DefaultTextField(
-                value = state.location,
+            ValidatedTextField(
+                field = state.location,
                 onValueChange = { onEvent(ProfileEditScreenEvent.OnLocationChanged(it)) },
                 placeholder = stringResource(R.string.profile_location_placeholder),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(TEXT_FIELD_HEIGHT),
-                onExpandedChange = {},
             )
             Spacer(Modifier.height(LINKS_SECTION_TOP_SPACER))
         }
@@ -185,11 +181,12 @@ fun PersonalInfoContent(
             )
             Spacer(Modifier.height(LINKS_SECTION_TITLE_BOTTOM_SPACER))
         }
-        ProfileEditState.SocialLinks.entries.forEach { platform ->
+        SocialLinks.entries.forEach { platform ->
             item {
                 SocialLinkField(
                     platform = platform,
-                    value = state.socialLinksUrlMap[platform].orEmpty(),
+                    field = state.socialLinks[platform]
+                        ?: ProfileEditState.ValidatedField("", null),
                     onValueChange = {
                         onEvent(
                             ProfileEditScreenEvent.OnSocialLinkChanged(
@@ -248,27 +245,56 @@ private fun ProfileAvatarSection(
 
 @Composable
 private fun SocialLinkField(
-    platform: ProfileEditState.SocialLinks,
-    value: String,
+    platform: SocialLinks,
+    field: ProfileEditState.ValidatedField,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier.padding(vertical = SOCIAL_LINK_VERTICAL_PADDING)) {
+    Column(modifier = modifier) {
         Text(
             text = platform.name,
             style = Theme.typography.body3Accent,
             color = Theme.colors.black900,
         )
         Spacer(Modifier.height(SOCIAL_LINK_VERTICAL_PADDING))
-        DefaultTextField(
-            value = value,
+        ValidatedTextField(
+            field = field,
             onValueChange = onValueChange,
             placeholder = stringResource(R.string.profile_link_placeholder),
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(TEXT_FIELD_HEIGHT),
-            onExpandedChange = {},
         )
+    }
+}
+
+@Composable
+private fun ValidatedTextField(
+    field: ProfileEditState.ValidatedField,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    modifier: Modifier = Modifier,
+) {
+    DefaultTextField(
+        value = field.value,
+        onValueChange = onValueChange,
+        placeholder = placeholder,
+        modifier = modifier
+            .fillMaxWidth()
+            .height(TEXT_FIELD_HEIGHT),
+        onExpandedChange = {},
+        isError = field.error != null,
+    )
+    ValidationErrorText(error = field.error)
+}
+
+@Composable
+private fun ValidationErrorText(error: TextOrResource?) {
+    Box(modifier = Modifier.height(VALIDATION_ERROR_HEIGHT)) {
+        error?.let {
+            Text(
+                text = it.getString(LocalContext.current),
+                style = Theme.typography.body7Alt,
+                color = Theme.colors.red700,
+            )
+        }
     }
 }
 
@@ -277,13 +303,21 @@ private fun SocialLinkField(
 fun ProfileEditPersonalInfoPreview() {
     val personalInfoState = ProfileEditState.PersonalInfoTabState(
         avatarUrl = null,
-        nickname = "John Doe",
+        nickname = ProfileEditState.ValidatedField("John Doe", null),
         specializationList = emptyList(),
         specialization = "Android Разработчик",
-        email = "johndoe@gmail.com",
-        location = "Санкт-Петербург",
-        socialLinksUrlMap = persistentMapOf(),
         isSpecializationEditable = false,
+        email = "johndoe@gmail.com",
+        location = ProfileEditState.ValidatedField("Санкт-Петербург", null),
+        socialLinks = persistentMapOf(
+            Pair(
+                SocialLinks.Linkedin,
+                ProfileEditState.ValidatedField(
+                    "",
+                    TextOrResource.Resource(R.string.error_max_length_255),
+                ),
+            ),
+        ),
     )
     PersonalInfoContent(state = personalInfoState, onEvent = {})
 }

--- a/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/tabs/ProfileEditPersonalInfoTab.kt
+++ b/feature/profile-edit/impl/src/main/java/ru/yeahub/profile_edit/impl/ui/tabs/ProfileEditPersonalInfoTab.kt
@@ -3,12 +3,14 @@ package ru.yeahub.profile_edit.impl.ui.tabs
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -116,15 +118,33 @@ fun PersonalInfoContent(
         item {
             FieldLabel(text = stringResource(R.string.profile_specialization_label))
             DropDownMenu(
-                placeholder = stringResource(R.string.profile_specialization_label),
+                placeholder = stringResource(R.string.profile_specialization_placeholder),
                 items = state.specializationList,
                 selected = state.specialization,
                 onSelected = { onEvent(ProfileEditScreenEvent.ChooseSpecialization(it)) },
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(TEXT_FIELD_HEIGHT),
+                leadingIcon = {
+                    Icon(
+                        painter = painterResource(R.drawable.icon_search),
+                        contentDescription = "Поиск",
+                        modifier = Modifier
+                            .width(20.dp)
+                            .height(20.dp),
+                    )
+                },
             )
-            Spacer(Modifier.height(FIELD_BOTTOM_SPACER))
+            TextButton(
+                onClick = { onEvent(ProfileEditScreenEvent.CannotChangeSpecializationToast) },
+                contentPadding = PaddingValues(0.dp),
+            ) {
+                Text(
+                    text = stringResource(R.string.profile_change_specialization),
+                    style = Theme.typography.head7,
+                    color = Theme.colors.purple700,
+                )
+            }
         }
         item {
             FieldLabel(text = stringResource(R.string.profile_email_label))
@@ -137,6 +157,7 @@ fun PersonalInfoContent(
                     .height(TEXT_FIELD_HEIGHT),
                 onExpandedChange = {},
                 readOnly = true,
+                isEnabled = false,
             )
             Spacer(Modifier.height(FIELD_BOTTOM_SPACER))
         }


### PR DESCRIPTION
🧩 Что сделано
**Presentation-слой**
1. Созданы Event, Result, Command вместо заглушек
2. В State добавлено поле hasUnsavedChanges
3. В State добавлено поле isSpecializationEditable
4. В State добавлен ValidatedField — поля с валидацией теперь имеют этот тип

**UI — диалог навигации**
6.Добавлен диалог предупреждения в вёрстку, добавлено превью
7.Пофикшены колбеки Core-UI элемента диалога (элемент не существует в develop, затронута только эпик-ветка)

**UI — первый таб**
8.В вёрстке первого таба заменены todo на настоящие Event, в вёрстке экрана тоже
9.Добавлена иконка поиска к выбору специализации и текстовая кнопка смены специализации (как на вебе)
10.В UI добавлена валидация полей, отображение ошибок

**UI — экран**
11.Добавлена кнопка «Сохранить» к экрану

**Рефакторинг**
12.Добавлен HorizontalPager для табов (в основном для сохранения положения прокрутки при переключении табов)
13.Замена TextButton на Text с clickable (для удобства вёрстки)

🗂 Затронутые модули
feature → profile-edit → impl
core → ui

📱Pixel perfect precision (референс-дизайн отсутствует)
<img width="322" height="697" alt="image" src="https://github.com/user-attachments/assets/63daa949-a6e5-4949-b698-63b3c52a77ed" /> <img width="322" height="697" alt="image" src="https://github.com/user-attachments/assets/271cdffb-18cc-49c6-91bb-aaff950a7344" />
<img width="322" height="697" alt="image" src="https://github.com/user-attachments/assets/2c1b6bbd-98b6-4ba1-a737-f56f43952a97" /> <img width="322" height="697" alt="image" src="https://github.com/user-attachments/assets/a0758a66-b210-4012-b053-47fcf5602684" />

Пиксель пёрфект 1го таба после рефакторинга сохранён.
<img width="342" height="731" alt="image" src="https://github.com/user-attachments/assets/d407deaa-17bc-4d90-959a-967ed140aadc" />

