### PR TITLE
Feature/ANDR-63-1 Публичный тренажер, экран результатов. Верстка экрана

### DIFF
--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultEvent.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultEvent.kt
@@ -2,8 +2,5 @@ package ru.yeahub.interview_trainer.impl.interviewQuizResult
 
 sealed interface InterviewQuizResultEvent {
 
-    data object Retry : InterviewQuizResultEvent
-    data object ShareResults : InterviewQuizResultEvent
-    data object ViewDetailedStats : InterviewQuizResultEvent
-    data object OnBackClick : InterviewQuizResultEvent
+    data object Todo: InterviewQuizResultEvent // TODO: сделать ивенты
 }

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultEvent.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultEvent.kt
@@ -1,0 +1,9 @@
+package ru.yeahub.interview_trainer.impl.interviewQuizResult
+
+sealed interface InterviewQuizResultEvent {
+
+    data object Retry : InterviewQuizResultEvent
+    data object ShareResults : InterviewQuizResultEvent
+    data object ViewDetailedStats : InterviewQuizResultEvent
+    data object OnBackClick : InterviewQuizResultEvent
+}

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultEvent.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultEvent.kt
@@ -2,5 +2,5 @@ package ru.yeahub.interview_trainer.impl.interviewQuizResult
 
 sealed interface InterviewQuizResultEvent {
 
-    data object Todo: InterviewQuizResultEvent // TODO: сделать ивенты
+    data object Todo : InterviewQuizResultEvent // TODO: сделать ивенты
 }

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultScreenMapper.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultScreenMapper.kt
@@ -1,9 +1,9 @@
 package ru.yeahub.interview_trainer.impl.interviewQuizResult
 
 import InterviewQuizResultState
-import ru.yeahub.interview_trainer.impl.R
 import kotlinx.collections.immutable.persistentListOf
 import ru.yeahub.core_utils.common.TextOrResource
+import ru.yeahub.interview_trainer.impl.R
 
 private const val DEFAULT_PERCENTAGE = 0.75f
 private const val DEFAULT_TOTAL_QUESTIONS = 20

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultScreenMapper.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultScreenMapper.kt
@@ -1,7 +1,9 @@
 package ru.yeahub.interview_trainer.impl.interviewQuizResult
 
 import InterviewQuizResultState
+import ru.yeahub.interview_trainer.impl.R
 import kotlinx.collections.immutable.persistentListOf
+import ru.yeahub.core_utils.common.TextOrResource
 
 private const val DEFAULT_PERCENTAGE = 0.75f
 private const val DEFAULT_TOTAL_QUESTIONS = 20
@@ -13,12 +15,14 @@ private const val DEFAULT_SKILL_MAX = 120
 
 class InterviewQuizResultScreenMapper {
 
-    fun getScreenState(): InterviewQuizResultState = InterviewQuizResultState.Loaded(
-        overallPercentage = DEFAULT_PERCENTAGE,
-        totalQuestions = DEFAULT_TOTAL_QUESTIONS,
-        newQuestions = DEFAULT_NEW_QUESTIONS,
-        inProgress = DEFAULT_IN_PROGRESS,
-        studied = DEFAULT_STUDIED,
+    fun getScreenState(): InterviewQuizResultState =
+        InterviewQuizResultState.Loaded(
+            titleTopAppBar = TextOrResource.Resource(R.string.create_quiz_top_bar_header_text),
+            overallPercentage = DEFAULT_PERCENTAGE,
+            totalQuestions = DEFAULT_TOTAL_QUESTIONS,
+            newQuestions = DEFAULT_NEW_QUESTIONS,
+            inProgress = DEFAULT_IN_PROGRESS,
+            studied = DEFAULT_STUDIED,
         skills = persistentListOf(
             InterviewQuizResultState.Loaded.VoSkillStat("HTML", DEFAULT_SKILL_SCORE, DEFAULT_SKILL_MAX),
             InterviewQuizResultState.Loaded.VoSkillStat("CSS", DEFAULT_SKILL_SCORE, DEFAULT_SKILL_MAX),

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultScreenMapper.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultScreenMapper.kt
@@ -1,0 +1,38 @@
+package ru.yeahub.interview_trainer.impl.interviewQuizResult
+
+import InterviewQuizResultState
+
+private const val DEFAULT_PERCENTAGE = 0.75f
+private const val DEFAULT_TOTAL_QUESTIONS = 20
+private const val DEFAULT_NEW_QUESTIONS = 50
+private const val DEFAULT_IN_PROGRESS = 120
+private const val DEFAULT_STUDIED = 12
+private const val DEFAULT_SKILL_SCORE = 60
+private const val DEFAULT_SKILL_MAX = 120
+
+class InterviewQuizResultScreenMapper {
+
+    fun getScreenState(): InterviewQuizResultState = InterviewQuizResultState.Loaded(
+        overallPercentage = DEFAULT_PERCENTAGE,
+        totalQuestions = DEFAULT_TOTAL_QUESTIONS,
+        newQuestions = DEFAULT_NEW_QUESTIONS,
+        inProgress = DEFAULT_IN_PROGRESS,
+        studied = DEFAULT_STUDIED,
+        skills = listOf(
+            InterviewQuizResultState.Loaded.VoSkillStat("HTML", DEFAULT_SKILL_SCORE, DEFAULT_SKILL_MAX),
+            InterviewQuizResultState.Loaded.VoSkillStat("CSS", DEFAULT_SKILL_SCORE, DEFAULT_SKILL_MAX),
+            InterviewQuizResultState.Loaded.VoSkillStat("JavaScript", DEFAULT_SKILL_SCORE, DEFAULT_SKILL_MAX),
+            InterviewQuizResultState.Loaded.VoSkillStat("React", DEFAULT_SKILL_SCORE, DEFAULT_SKILL_MAX),
+            InterviewQuizResultState.Loaded.VoSkillStat("PHP", DEFAULT_SKILL_SCORE, DEFAULT_SKILL_MAX),
+            InterviewQuizResultState.Loaded.VoSkillStat("JavaScript", DEFAULT_SKILL_SCORE, DEFAULT_SKILL_MAX)
+        ),
+        questions = listOf(
+            InterviewQuizResultState.Loaded.VoQuestionResult("Что такое Virtual DOM, и как он работает?", false),
+            InterviewQuizResultState.Loaded.VoQuestionResult("Что такое Virtual DOM, и как он работает?", true),
+            InterviewQuizResultState.Loaded.VoQuestionResult("Что такое Virtual DOM, и как он работает?", true),
+            InterviewQuizResultState.Loaded.VoQuestionResult("Что такое Virtual DOM, и как он работает?", false),
+            InterviewQuizResultState.Loaded.VoQuestionResult("Что такое Virtual DOM, и как он работает?", true),
+            InterviewQuizResultState.Loaded.VoQuestionResult("Что такое Virtual DOM, и как он работает?", false)
+        )
+    )
+}

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultScreenMapper.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultScreenMapper.kt
@@ -1,6 +1,7 @@
 package ru.yeahub.interview_trainer.impl.interviewQuizResult
 
 import InterviewQuizResultState
+import kotlinx.collections.immutable.persistentListOf
 
 private const val DEFAULT_PERCENTAGE = 0.75f
 private const val DEFAULT_TOTAL_QUESTIONS = 20
@@ -18,7 +19,7 @@ class InterviewQuizResultScreenMapper {
         newQuestions = DEFAULT_NEW_QUESTIONS,
         inProgress = DEFAULT_IN_PROGRESS,
         studied = DEFAULT_STUDIED,
-        skills = listOf(
+        skills = persistentListOf(
             InterviewQuizResultState.Loaded.VoSkillStat("HTML", DEFAULT_SKILL_SCORE, DEFAULT_SKILL_MAX),
             InterviewQuizResultState.Loaded.VoSkillStat("CSS", DEFAULT_SKILL_SCORE, DEFAULT_SKILL_MAX),
             InterviewQuizResultState.Loaded.VoSkillStat("JavaScript", DEFAULT_SKILL_SCORE, DEFAULT_SKILL_MAX),
@@ -26,7 +27,7 @@ class InterviewQuizResultScreenMapper {
             InterviewQuizResultState.Loaded.VoSkillStat("PHP", DEFAULT_SKILL_SCORE, DEFAULT_SKILL_MAX),
             InterviewQuizResultState.Loaded.VoSkillStat("JavaScript", DEFAULT_SKILL_SCORE, DEFAULT_SKILL_MAX)
         ),
-        questions = listOf(
+        questions = persistentListOf(
             InterviewQuizResultState.Loaded.VoQuestionResult("Что такое Virtual DOM, и как он работает?", false),
             InterviewQuizResultState.Loaded.VoQuestionResult("Что такое Virtual DOM, и как он работает?", true),
             InterviewQuizResultState.Loaded.VoQuestionResult("Что такое Virtual DOM, и как он работает?", true),

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultState.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultState.kt
@@ -1,5 +1,7 @@
 import androidx.compose.runtime.Immutable
+import kotlinx.collections.immutable.PersistentList
 
+@Immutable
 sealed interface InterviewQuizResultState {
     data object Loading : InterviewQuizResultState
 
@@ -9,8 +11,8 @@ sealed interface InterviewQuizResultState {
         val newQuestions: Int,
         val inProgress: Int,
         val studied: Int,
-        val skills: List<VoSkillStat>,
-        val questions: List<VoQuestionResult>
+        val skills: PersistentList<VoSkillStat>,
+        val questions: PersistentList<VoQuestionResult>
     ) : InterviewQuizResultState {
         @Immutable
         data class VoSkillStat(

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultState.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultState.kt
@@ -1,11 +1,19 @@
 import androidx.compose.runtime.Immutable
 import kotlinx.collections.immutable.PersistentList
+import ru.yeahub.core_utils.common.TextOrResource
+import ru.yeahub.interview_trainer.impl.R
 
 @Immutable
 sealed interface InterviewQuizResultState {
-    data object Loading : InterviewQuizResultState
+
+    val titleTopAppBar: TextOrResource
+
+    data object Loading : InterviewQuizResultState {
+        override val titleTopAppBar = TextOrResource.Resource(R.string.create_quiz_top_bar_header_text)
+    }
 
     data class Loaded(
+        override val titleTopAppBar: TextOrResource,
         val overallPercentage: Float,
         val totalQuestions: Int,
         val newQuestions: Int,
@@ -14,6 +22,7 @@ sealed interface InterviewQuizResultState {
         val skills: PersistentList<VoSkillStat>,
         val questions: PersistentList<VoQuestionResult>
     ) : InterviewQuizResultState {
+
         @Immutable
         data class VoSkillStat(
             val name: String,
@@ -28,5 +37,9 @@ sealed interface InterviewQuizResultState {
         )
     }
 
-    data class Error(val throwable: Throwable) : InterviewQuizResultState
+    data class Error(
+        val throwable: Throwable
+    ) : InterviewQuizResultState {
+        override val titleTopAppBar = TextOrResource.Resource(R.string.create_quiz_top_bar_header_text)
+    }
 }

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultState.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultState.kt
@@ -1,0 +1,30 @@
+import androidx.compose.runtime.Immutable
+
+sealed interface InterviewQuizResultState {
+    data object Loading : InterviewQuizResultState
+
+    data class Loaded(
+        val overallPercentage: Float,
+        val totalQuestions: Int,
+        val newQuestions: Int,
+        val inProgress: Int,
+        val studied: Int,
+        val skills: List<VoSkillStat>,
+        val questions: List<VoQuestionResult>
+    ) : InterviewQuizResultState {
+        @Immutable
+        data class VoSkillStat(
+            val name: String,
+            val current: Int,
+            val max: Int
+        )
+
+        @Immutable
+        data class VoQuestionResult(
+            val questionText: String,
+            val isCorrect: Boolean
+        )
+    }
+
+    data class Error(val throwable: Throwable) : InterviewQuizResultState
+}

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultViewModel.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultViewModel.kt
@@ -7,6 +7,8 @@ import kotlinx.coroutines.flow.stateIn
 import ru.yeahub.interview_trainer.impl.interviewQuizResult.InterviewQuizResultEvent
 import ru.yeahub.interview_trainer.impl.interviewQuizResult.InterviewQuizResultScreenMapper
 
+private const val STOP_TIMEOUT_MILLIS = 5000L
+
 class InterviewQuizResultViewModel(
     private val mapper: InterviewQuizResultScreenMapper
 ) : ViewModel() {
@@ -17,7 +19,7 @@ class InterviewQuizResultViewModel(
         }
             .stateIn(
                 scope = viewModelScope,
-                started = SharingStarted.WhileSubscribed(5000),
+                started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_MILLIS),
                 initialValue = InterviewQuizResultState.Loading
             )
 

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultViewModel.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultViewModel.kt
@@ -1,27 +1,27 @@
 import androidx.lifecycle.ViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
 import ru.yeahub.interview_trainer.impl.interviewQuizResult.InterviewQuizResultEvent
+import ru.yeahub.interview_trainer.impl.interviewQuizResult.InterviewQuizResultScreenMapper
 
-class InterviewQuizResultViewModel : ViewModel() {
+class InterviewQuizResultViewModel(
+    private val mapper: InterviewQuizResultScreenMapper
+) : ViewModel() {
 
-    private val _state =
-        MutableStateFlow<InterviewQuizResultState>(InterviewQuizResultState.Loading)
-
-    val state: StateFlow<InterviewQuizResultState> = _state
+    val state: StateFlow<InterviewQuizResultState> =
+        flow {
+            emit(mapper.getScreenState())
+        }
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5000),
+                initialValue = InterviewQuizResultState.Loading
+            )
 
     fun onEvent(event: InterviewQuizResultEvent) {
-        when (event) {
-            InterviewQuizResultEvent.OnBackClick -> {
-                // TODO
-            }
-
-            InterviewQuizResultEvent.ViewDetailedStats -> {
-                // TODO
-            }
-
-            InterviewQuizResultEvent.Retry -> TODO()
-            InterviewQuizResultEvent.ShareResults -> TODO()
-        }
+        // TODO:
     }
 }

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultViewModel.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultViewModel.kt
@@ -1,4 +1,3 @@
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultViewModel.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultViewModel.kt
@@ -1,0 +1,27 @@
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import ru.yeahub.interview_trainer.impl.interviewQuizResult.InterviewQuizResultEvent
+
+class InterviewQuizResultViewModel : ViewModel() {
+
+    private val _state =
+        MutableStateFlow<InterviewQuizResultState>(InterviewQuizResultState.Loading)
+
+    val state: StateFlow<InterviewQuizResultState> = _state
+
+    fun onEvent(event: InterviewQuizResultEvent) {
+        when (event) {
+            InterviewQuizResultEvent.OnBackClick -> {
+                // TODO
+            }
+
+            InterviewQuizResultEvent.ViewDetailedStats -> {
+                // TODO
+            }
+
+            InterviewQuizResultEvent.Retry -> TODO()
+            InterviewQuizResultEvent.ShareResults -> TODO()
+        }
+    }
+}

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultViewModel.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/InterviewQuizResultViewModel.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.stateIn
+import ru.yeahub.core_utils.BaseViewModel
 import ru.yeahub.interview_trainer.impl.interviewQuizResult.InterviewQuizResultEvent
 import ru.yeahub.interview_trainer.impl.interviewQuizResult.InterviewQuizResultScreenMapper
 
@@ -11,7 +12,7 @@ private const val STOP_TIMEOUT_MILLIS = 5000L
 
 class InterviewQuizResultViewModel(
     private val mapper: InterviewQuizResultScreenMapper
-) : ViewModel() {
+) : BaseViewModel() {
 
     val state: StateFlow<InterviewQuizResultState> =
         flow {

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/ui/InterviewQuizResultScreen.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/ui/InterviewQuizResultScreen.kt
@@ -52,9 +52,7 @@ import ru.yeahub.core_ui.component.KnownAnswerButton
 import ru.yeahub.core_ui.component.TopAppBarWithBottomBorder
 import ru.yeahub.core_ui.component.UnknownAnswerButton
 import ru.yeahub.core_ui.example.staticPreview.StaticPreview
-import ru.yeahub.core_ui.theme.Colors
 import ru.yeahub.core_ui.theme.Theme.typography
-import ru.yeahub.core_ui.theme.Typography
 import ru.yeahub.core_ui.theme.colors
 import ru.yeahub.core_utils.common.TextOrResource
 import ru.yeahub.interview_trainer.impl.R

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/ui/InterviewQuizResultScreen.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/ui/InterviewQuizResultScreen.kt
@@ -57,7 +57,6 @@ import ru.yeahub.core_ui.theme.Typography
 import ru.yeahub.core_ui.theme.colors
 import ru.yeahub.core_utils.common.TextOrResource
 import ru.yeahub.interview_trainer.impl.R
-import ru.yeahub.interview_trainer.impl.interviewQuiz.presentation.InterviewQuizState
 import ru.yeahub.interview_trainer.impl.interviewQuizResult.InterviewQuizResultEvent
 
 private val H_PADDING = 16.dp
@@ -98,7 +97,8 @@ private fun ScreenUI(
     ) { innerPadding ->
         when (val currentState = state.value) {
             is InterviewQuizResultState.Loading -> {
-                InterviewQuizResultLoadingContent()
+                InterviewQuizResultLoading()
+
             }
 
             is InterviewQuizResultState.Error -> {
@@ -137,10 +137,8 @@ private fun BaseInterviewQuizResultScreen(
             .padding(horizontal = H_PADDING),
         verticalArrangement = Arrangement.spacedBy(V_SECTION)
     ) {
-        TitleSection(
-            typography = typography,
-            colors = colors
-        )
+        TitleSection()
+
         Card(
             shape = RoundedCornerShape(CARD_RADIUS),
             elevation = CardDefaults.cardElevation(CARD_ELEVATION),
@@ -174,7 +172,7 @@ private fun BaseInterviewQuizResultScreen(
                 Spacer(Modifier.height(V_BLOCK))
 
                 state.skills.forEach { skill ->
-                    SkillProgressRow(skill, colors, typography)
+                    SkillProgressRow(skill)
                 }
 
                 Spacer(Modifier.height(V_TINY))
@@ -219,20 +217,10 @@ private fun BaseInterviewQuizResultScreen(
     }
 }
 
-@Composable
-private fun InterviewQuizResultLoadingContent() {
-    Box(
-        modifier = Modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
-    ) {
-        CircularProgressIndicator()
-    }
-}
+
 
 @Composable
 private fun TitleSection(
-    typography: Typography,
-    colors: Colors
 ) {
     Text(
         text = stringResource(R.string.interview_quiz_result_result),
@@ -243,11 +231,7 @@ private fun TitleSection(
 }
 
 @Composable
-private fun SkillProgressRow(
-    skill: InterviewQuizResultState.Loaded.VoSkillStat,
-    colors: Colors,
-    typography: Typography
-) {
+private fun SkillProgressRow(skill: InterviewQuizResultState.Loaded.VoSkillStat) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -475,6 +459,7 @@ private fun QuestionItem(
         }
     }
 }
+
 
 @StaticPreview
 @Composable

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/ui/InterviewQuizResultScreen.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/ui/InterviewQuizResultScreen.kt
@@ -158,8 +158,6 @@ private fun BaseInterviewQuizResultScreen(
                     newQuestions = state.newQuestions,
                     inProgress = state.inProgress,
                     studied = state.studied,
-                    colors = colors,
-                    typography = typography
                 )
 
                 Spacer(Modifier.height(32.dp))
@@ -209,7 +207,7 @@ private fun BaseInterviewQuizResultScreen(
                 )
 
                 state.questions.forEach { question ->
-                    QuestionItem(question, colors, typography)
+                    QuestionItem(question)
                 }
             }
         }
@@ -274,9 +272,7 @@ private fun SkillProgressRow(skill: InterviewQuizResultState.Loaded.VoSkillStat)
 @Composable
 private fun StatItem(
     label: String,
-    value: String,
-    colors: Colors,
-    typography: Typography
+    value: String
 ) {
     Card(
         modifier = Modifier
@@ -312,9 +308,7 @@ private fun OverallProgressStatistics(
     totalQuestions: Int,
     newQuestions: Int,
     inProgress: Int,
-    studied: Int,
-    colors: Colors,
-    typography: Typography
+    studied: Int
 ) {
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -375,27 +369,19 @@ private fun OverallProgressStatistics(
         ) {
             StatItem(
                 stringResource(R.string.interview_quiz_result_overall),
-                totalQuestions.toString(),
-                colors,
-                typography
+                totalQuestions.toString()
             )
             StatItem(
                 stringResource(R.string.interview_quiz_result_new),
-                newQuestions.toString(),
-                colors,
-                typography
+                newQuestions.toString()
             )
             StatItem(
                 stringResource(R.string.interview_quiz_result_in_progress),
-                inProgress.toString(),
-                colors,
-                typography
+                inProgress.toString()
             )
             StatItem(
                 stringResource(R.string.interview_quiz_result_studied),
-                studied.toString(),
-                colors,
-                typography
+                studied.toString()
             )
         }
     }
@@ -403,9 +389,7 @@ private fun OverallProgressStatistics(
 
 @Composable
 private fun QuestionItem(
-    question: InterviewQuizResultState.Loaded.VoQuestionResult,
-    colors: Colors,
-    typography: Typography
+    question: InterviewQuizResultState.Loaded.VoQuestionResult
 ) {
     Card(
         modifier = Modifier

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/ui/InterviewQuizResultScreen.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/ui/InterviewQuizResultScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.collections.immutable.persistentListOf
 import org.koin.androidx.compose.koinViewModel
 import ru.yeahub.core_ui.component.ErrorScreen
 import ru.yeahub.core_ui.component.KnownAnswerButton
@@ -91,7 +92,7 @@ private fun ScreenUI(
         topBar = {
             TopAppBarWithBottomBorder(
                 title = TextOrResource.Resource(R.string.create_quiz_top_bar_header_text),
-                onBackClick = { onEvent(InterviewQuizResultEvent.OnBackClick) }
+                onBackClick = {  }
             )
         }
     ) { innerPadding ->
@@ -186,7 +187,7 @@ private fun BaseInterviewQuizResultScreen(
                         style = typography.body3,
                         color = colors.purple700,
                         modifier = Modifier.clickable {
-                            onEvent(InterviewQuizResultEvent.ViewDetailedStats)
+                            onEvent(InterviewQuizResultEvent.Todo)
                         }
                     )
                 }
@@ -484,7 +485,7 @@ class InterviewQuizResultStateParamProvider :
             newQuestions = 50,
             inProgress = 120,
             studied = 12,
-            skills = listOf(
+            skills = persistentListOf(
                 InterviewQuizResultState.Loaded.VoSkillStat("HTML", 60, 120),
                 InterviewQuizResultState.Loaded.VoSkillStat("CSS", 60, 120),
                 InterviewQuizResultState.Loaded.VoSkillStat("JavaScript", 60, 120),
@@ -492,7 +493,7 @@ class InterviewQuizResultStateParamProvider :
                 InterviewQuizResultState.Loaded.VoSkillStat("PHP", 60, 120),
                 InterviewQuizResultState.Loaded.VoSkillStat("JavaScript", 60, 120)
             ),
-            questions = listOf(
+            questions = persistentListOf(
                 InterviewQuizResultState.Loaded.VoQuestionResult(
                     "Что такое Virtual DOM, и как он работает?",
                     false

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/ui/InterviewQuizResultScreen.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/ui/InterviewQuizResultScreen.kt
@@ -47,7 +47,9 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.koin.androidx.compose.koinViewModel
 import ru.yeahub.core_ui.component.ErrorScreen
+import ru.yeahub.core_ui.component.KnownAnswerButton
 import ru.yeahub.core_ui.component.TopAppBarWithBottomBorder
+import ru.yeahub.core_ui.component.UnknownAnswerButton
 import ru.yeahub.core_ui.example.staticPreview.StaticPreview
 import ru.yeahub.core_ui.theme.Colors
 import ru.yeahub.core_ui.theme.Theme.typography
@@ -55,6 +57,7 @@ import ru.yeahub.core_ui.theme.Typography
 import ru.yeahub.core_ui.theme.colors
 import ru.yeahub.core_utils.common.TextOrResource
 import ru.yeahub.interview_trainer.impl.R
+import ru.yeahub.interview_trainer.impl.interviewQuiz.presentation.InterviewQuizState
 import ru.yeahub.interview_trainer.impl.interviewQuizResult.InterviewQuizResultEvent
 
 private val H_PADDING = 16.dp
@@ -454,14 +457,19 @@ private fun QuestionItem(
                 ) {
                     val isCorrect = question.isCorrect
 
-                    Text(
-                        text = if (isCorrect) "👍" else "👎",
-                        color = if (isCorrect) Color(0xFF6C3CF0) else Color(0xFF9E9E9E),
-                        style = typography.body3
-                    )
-
-
-                    )
+                    if (isCorrect) {
+                        KnownAnswerButton(
+                            enabled = false,
+                            isHighlighted = true,
+                            onClick = {}
+                        )
+                    } else {
+                        UnknownAnswerButton(
+                            enabled = false,
+                            isHighlighted = false,
+                            onClick = {}
+                        )
+                    }
                 }
             }
         }

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/ui/InterviewQuizResultScreen.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/ui/InterviewQuizResultScreen.kt
@@ -65,7 +65,6 @@ private val V_TINY = 8.dp
 private val CARD_RADIUS = 12.dp
 private val CARD_ELEVATION = 4.dp
 private val SKILL_BAR_HEIGHT = 12.dp
-private val SKILL_BAR_SPACING = 12.dp
 
 @Composable
 fun InterviewQuizResultScreen() {
@@ -156,14 +155,14 @@ private fun BaseInterviewQuizResultScreen(
                     studied = state.studied,
                 )
 
-                Spacer(Modifier.height(32.dp))
+                Spacer(Modifier.height(16.dp))
 
                 Text(
                     text = stringResource(R.string.interview_quiz_result_progress),
-                    style = typography.head4,
+                    style = typography.body3Strong,
                     color = colors.black900
                 )
-                Spacer(Modifier.height(V_BLOCK))
+                Spacer(Modifier.height(13.dp))
 
                 state.skills.forEach { skill ->
                     SkillProgressRow(skill)
@@ -217,7 +216,7 @@ private fun TitleSection() {
         text = stringResource(R.string.interview_quiz_result_result),
         style = typography.head5,
         color = colors.black900,
-        modifier = Modifier.padding(top = 16.dp)
+        modifier = Modifier.padding(top = 24.dp)
     )
 }
 
@@ -228,31 +227,15 @@ private fun SkillProgressRow(skill: InterviewQuizResultState.Loaded.VoSkillStat)
             .fillMaxWidth()
             .padding(vertical = 6.dp)
     ) {
-        Text(
-            text = skill.name,
-            style = typography.body3Strong,
-            color = colors.black900,
-            modifier = Modifier.padding(bottom = 4.dp)
-        )
-
         Row(
             modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically
+            horizontalArrangement = Arrangement.SpaceBetween
         ) {
-            LinearProgressIndicator(
-                progress = { skill.current.toFloat() / skill.max },
-                modifier = Modifier
-                    .weight(1f)
-                    .height(SKILL_BAR_HEIGHT)
-                    .clip(RoundedCornerShape(4.dp)),
-                color = colors.purple700,
-                trackColor = colors.purple400,
-                strokeCap = StrokeCap.Round,
-                gapSize = (-10).dp,
-                drawStopIndicator = {}
+            Text(
+                text = skill.name,
+                style = typography.body3Strong,
+                color = colors.black900
             )
-
-            Spacer(Modifier.width(SKILL_BAR_SPACING))
 
             Text(
                 text = "${skill.current}/${skill.max}".trim(),
@@ -262,6 +245,21 @@ private fun SkillProgressRow(skill: InterviewQuizResultState.Loaded.VoSkillStat)
                 overflow = TextOverflow.Ellipsis
             )
         }
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        LinearProgressIndicator(
+            progress = { skill.current.toFloat() / skill.max },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(SKILL_BAR_HEIGHT)
+                .clip(RoundedCornerShape(4.dp)),
+            color = colors.purple700,
+            trackColor = colors.purple400,
+            strokeCap = StrokeCap.Round,
+            gapSize = (-10).dp,
+            drawStopIndicator = {}
+        )
     }
 }
 
@@ -313,7 +311,7 @@ private fun OverallProgressStatistics(
         Spacer(Modifier.height(8.dp))
 
         Box(
-            modifier = Modifier.size(240.dp),
+            modifier = Modifier.size(250.dp),
             contentAlignment = Alignment.Center
         ) {
             Box(
@@ -404,7 +402,7 @@ private fun QuestionItem(
         ) {
             Box(
                 modifier = Modifier
-                    .size(72.dp)
+                    .size(104.dp)
                     .clip(RoundedCornerShape(12.dp))
                     .background(Color(0xFF0F1C2E))
             ) {

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/ui/InterviewQuizResultScreen.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/ui/InterviewQuizResultScreen.kt
@@ -93,11 +93,11 @@ private fun ScreenUI(
             )
         }
     ) { innerPadding ->
-
         when (val currentState = state.value) {
             is InterviewQuizResultState.Loading -> {
                 InterviewQuizResultLoadingContent()
             }
+
             is InterviewQuizResultState.Error -> {
                 ErrorScreen(
                     error = currentState.throwable.localizedMessage,
@@ -108,7 +108,6 @@ private fun ScreenUI(
                     onBack = {}
                 )
             }
-
             is InterviewQuizResultState.Loaded -> {
                 BaseInterviewQuizResultScreen(
                     state = currentState,
@@ -203,7 +202,7 @@ private fun BaseInterviewQuizResultScreen(
             ) {
                 Text(
                     text = stringResource(R.string.interview_quiz_result_questuions),
-                    style = typography.head5,
+                    style = typography.body4,
                     color = colors.black900,
                     modifier = Modifier.padding(bottom = 12.dp)
                 )
@@ -235,7 +234,8 @@ private fun TitleSection(
     Text(
         text = stringResource(R.string.interview_quiz_result_result),
         style = typography.head5,
-        color = colors.black900
+        color = colors.black900,
+        modifier = Modifier.padding(top = 16.dp)
     )
 }
 
@@ -376,7 +376,7 @@ private fun OverallProgressStatistics(
                     color = colors.black700
                 )
                 Text(
-                    text = "пройдено",
+                    text = stringResource(R.string.interview_quiz_result_done),
                     style = typography.body4,
                     color = colors.black700
                 )
@@ -389,10 +389,10 @@ private fun OverallProgressStatistics(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            StatItem("Всего", totalQuestions.toString(), colors, typography)
-            StatItem("Новые", newQuestions.toString(), colors, typography)
-            StatItem("В процессе", inProgress.toString(), colors, typography)
-            StatItem("Изучено", studied.toString(), colors, typography)
+            StatItem(stringResource(R.string.interview_quiz_result_overall), totalQuestions.toString(), colors, typography)
+            StatItem(stringResource(R.string.interview_quiz_result_new), newQuestions.toString(), colors, typography)
+            StatItem(stringResource(R.string.interview_quiz_result_in_progress), inProgress.toString(), colors, typography)
+            StatItem(stringResource(R.string.interview_quiz_result_studied), studied.toString(), colors, typography)
         }
     }
 }
@@ -460,12 +460,7 @@ private fun QuestionItem(
                         style = typography.body3
                     )
 
-                    Spacer(modifier = Modifier.width(6.dp))
 
-                    Text(
-                        text = if (isCorrect) "Знаю" else "Не знаю",
-                        color = if (isCorrect) Color(0xFF6C3CF0) else Color(0xFF9E9E9E),
-                        style = typography.body3
                     )
                 }
             }

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/ui/InterviewQuizResultScreen.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/ui/InterviewQuizResultScreen.kt
@@ -99,7 +99,6 @@ private fun ScreenUI(
         when (val currentState = state.value) {
             is InterviewQuizResultState.Loading -> {
                 InterviewQuizResultLoading()
-
             }
 
             is InterviewQuizResultState.Error -> {
@@ -218,11 +217,8 @@ private fun BaseInterviewQuizResultScreen(
     }
 }
 
-
-
 @Composable
-private fun TitleSection(
-) {
+private fun TitleSection() {
     Text(
         text = stringResource(R.string.interview_quiz_result_result),
         style = typography.head5,
@@ -377,10 +373,30 @@ private fun OverallProgressStatistics(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            StatItem(stringResource(R.string.interview_quiz_result_overall), totalQuestions.toString(), colors, typography)
-            StatItem(stringResource(R.string.interview_quiz_result_new), newQuestions.toString(), colors, typography)
-            StatItem(stringResource(R.string.interview_quiz_result_in_progress), inProgress.toString(), colors, typography)
-            StatItem(stringResource(R.string.interview_quiz_result_studied), studied.toString(), colors, typography)
+            StatItem(
+                stringResource(R.string.interview_quiz_result_overall),
+                totalQuestions.toString(),
+                colors,
+                typography
+            )
+            StatItem(
+                stringResource(R.string.interview_quiz_result_new),
+                newQuestions.toString(),
+                colors,
+                typography
+            )
+            StatItem(
+                stringResource(R.string.interview_quiz_result_in_progress),
+                inProgress.toString(),
+                colors,
+                typography
+            )
+            StatItem(
+                stringResource(R.string.interview_quiz_result_studied),
+                studied.toString(),
+                colors,
+                typography
+            )
         }
     }
 }
@@ -460,7 +476,6 @@ private fun QuestionItem(
         }
     }
 }
-
 
 @StaticPreview
 @Composable

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/ui/InterviewQuizResultScreen.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/ui/InterviewQuizResultScreen.kt
@@ -1,0 +1,531 @@
+package ru.yeahub.interview_trainer.impl.interviewQuizResult.ui
+
+import InterviewQuizResultState
+import InterviewQuizResultViewModel
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import org.koin.androidx.compose.koinViewModel
+import ru.yeahub.core_ui.component.ErrorScreen
+import ru.yeahub.core_ui.component.TopAppBarWithBottomBorder
+import ru.yeahub.core_ui.example.staticPreview.StaticPreview
+import ru.yeahub.core_ui.theme.Colors
+import ru.yeahub.core_ui.theme.Theme.typography
+import ru.yeahub.core_ui.theme.Typography
+import ru.yeahub.core_ui.theme.colors
+import ru.yeahub.core_utils.common.TextOrResource
+import ru.yeahub.interview_trainer.impl.R
+import ru.yeahub.interview_trainer.impl.interviewQuizResult.InterviewQuizResultEvent
+
+private val H_PADDING = 16.dp
+private val V_BLOCK = 16.dp
+private val V_SECTION = 32.dp
+private val V_TINY = 8.dp
+private val CARD_RADIUS = 12.dp
+private val CARD_ELEVATION = 4.dp
+private val SKILL_BAR_HEIGHT = 12.dp
+private val SKILL_BAR_SPACING = 12.dp
+
+@Composable
+fun InterviewQuizResultScreen(titleTopAppBarResId: Int) {
+    val viewModel: InterviewQuizResultViewModel = koinViewModel()
+    val state = viewModel.state.collectAsStateWithLifecycle()
+
+    ScreenUI(
+        state = state,
+        onEvent = viewModel::onEvent,
+        titleTopAppBar = TextOrResource.Resource(titleTopAppBarResId)
+    )
+}
+
+@Composable
+private fun ScreenUI(
+    state: State<InterviewQuizResultState>,
+    onEvent: (InterviewQuizResultEvent) -> Unit,
+    titleTopAppBar: TextOrResource,
+) {
+    Scaffold(
+        containerColor = colors.black10,
+        topBar = {
+            TopAppBarWithBottomBorder(
+                title = TextOrResource.Resource(R.string.create_quiz_top_bar_header_text),
+                onBackClick = { onEvent(InterviewQuizResultEvent.OnBackClick) }
+            )
+        }
+    ) { innerPadding ->
+
+        when (val currentState = state.value) {
+            is InterviewQuizResultState.Loading -> {
+                InterviewQuizResultLoadingContent()
+            }
+            is InterviewQuizResultState.Error -> {
+                ErrorScreen(
+                    error = currentState.throwable.localizedMessage,
+                    errorText = TextOrResource.Resource(R.string.error_screen_text),
+                    titleText = TextOrResource.Resource(R.string.title_error_screen_text),
+                    backText = TextOrResource.Resource(R.string.back_error_screen_text),
+                    unknownErrorText = TextOrResource.Resource(R.string.unknown_error_screen_text),
+                    onBack = {}
+                )
+            }
+
+            is InterviewQuizResultState.Loaded -> {
+                BaseInterviewQuizResultScreen(
+                    state = currentState,
+                    innerPadding = innerPadding,
+                    onEvent = onEvent
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BaseInterviewQuizResultScreen(
+    state: InterviewQuizResultState.Loaded,
+    innerPadding: PaddingValues,
+    onEvent: (InterviewQuizResultEvent) -> Unit
+) {
+    val scrollState = rememberScrollState()
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(innerPadding)
+            .verticalScroll(scrollState)
+            .padding(horizontal = H_PADDING),
+        verticalArrangement = Arrangement.spacedBy(V_SECTION)
+    ) {
+        TitleSection(
+            typography = typography,
+            colors = colors
+        )
+        Card(
+            shape = RoundedCornerShape(CARD_RADIUS),
+            elevation = CardDefaults.cardElevation(CARD_ELEVATION),
+            colors = CardDefaults.cardColors(containerColor = Color.White),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Column(modifier = Modifier.padding(H_PADDING)) {
+                Text(
+                    text = stringResource(R.string.interview_quiz_result_statistics),
+                    style = typography.body3Accent.copy(fontWeight = FontWeight.Bold),
+                    color = colors.black900
+                )
+                Spacer(Modifier.height(V_BLOCK))
+                OverallProgressStatistics(
+                    percentage = state.overallPercentage.coerceIn(0f, 1f),
+                    totalQuestions = state.totalQuestions,
+                    newQuestions = state.newQuestions,
+                    inProgress = state.inProgress,
+                    studied = state.studied,
+                    colors = colors,
+                    typography = typography
+                )
+
+                Spacer(Modifier.height(32.dp))
+
+                Text(
+                    text = stringResource(R.string.interview_quiz_result_progress),
+                    style = typography.head4,
+                    color = colors.black900
+                )
+                Spacer(Modifier.height(V_BLOCK))
+
+                state.skills.forEach { skill ->
+                    SkillProgressRow(skill, colors, typography)
+                }
+
+                Spacer(Modifier.height(V_TINY))
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End
+                ) {
+                    Text(
+                        text = stringResource(R.string.interview_quiz_result_show_all),
+                        style = typography.body3,
+                        color = colors.purple700,
+                        modifier = Modifier.clickable {
+                            onEvent(InterviewQuizResultEvent.ViewDetailedStats)
+                        }
+                    )
+                }
+            }
+        }
+        Card(
+            shape = RoundedCornerShape(CARD_RADIUS),
+            elevation = CardDefaults.cardElevation(CARD_ELEVATION),
+            colors = CardDefaults.cardColors(containerColor = Color.White),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Column(
+                modifier = Modifier.padding(H_PADDING)
+            ) {
+                Text(
+                    text = stringResource(R.string.interview_quiz_result_questuions),
+                    style = typography.head5,
+                    color = colors.black900,
+                    modifier = Modifier.padding(bottom = 12.dp)
+                )
+
+                state.questions.forEach { question ->
+                    QuestionItem(question, colors, typography)
+                }
+            }
+        }
+        Spacer(Modifier.height(V_SECTION))
+    }
+}
+
+@Composable
+private fun InterviewQuizResultLoadingContent() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun TitleSection(
+    typography: Typography,
+    colors: Colors
+) {
+    Text(
+        text = stringResource(R.string.interview_quiz_result_result),
+        style = typography.head5,
+        color = colors.black900
+    )
+}
+
+@Composable
+private fun SkillProgressRow(
+    skill: InterviewQuizResultState.Loaded.VoSkillStat,
+    colors: Colors,
+    typography: Typography
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 6.dp)
+    ) {
+        Text(
+            text = skill.name,
+            style = typography.body3Strong,
+            color = colors.black900,
+            modifier = Modifier.padding(bottom = 4.dp)
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            LinearProgressIndicator(
+                progress = { skill.current.toFloat() / skill.max },
+                modifier = Modifier
+                    .weight(1f)
+                    .height(SKILL_BAR_HEIGHT)
+                    .clip(RoundedCornerShape(4.dp)),
+                color = colors.purple700,
+                trackColor = colors.purple400,
+                strokeCap = StrokeCap.Round,
+                gapSize = (-10).dp,
+                drawStopIndicator = {}
+            )
+
+            Spacer(Modifier.width(SKILL_BAR_SPACING))
+
+            Text(
+                text = "${skill.current}/${skill.max}".trim(),
+                style = typography.body3Strong,
+                color = colors.black900,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatItem(
+    label: String,
+    value: String,
+    colors: Colors,
+    typography: Typography
+) {
+    Card(
+        modifier = Modifier
+            .widthIn(min = 72.dp)
+            .height(60.dp),
+        shape = RoundedCornerShape(12.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White)
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = label,
+                style = typography.body2,
+                color = colors.black400,
+                maxLines = 1
+            )
+
+            Text(
+                text = value,
+                style = typography.body3Strong,
+                color = colors.black800
+            )
+        }
+    }
+}
+
+@Composable
+private fun OverallProgressStatistics(
+    percentage: Float,
+    totalQuestions: Int,
+    newQuestions: Int,
+    inProgress: Int,
+    studied: Int,
+    colors: Colors,
+    typography: Typography
+) {
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Spacer(Modifier.height(8.dp))
+
+        Box(
+            modifier = Modifier.size(240.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(
+                        color = colors.yellow600.copy(alpha = 0.15f),
+                        shape = CircleShape
+                    )
+            )
+
+            CircularProgressIndicator(
+                progress = { 1f },
+                modifier = Modifier.fillMaxSize(),
+                color = colors.yellow600.copy(alpha = 0.5f),
+                strokeWidth = 24.dp,
+                strokeCap = StrokeCap.Butt,
+                trackColor = Color.Transparent
+            )
+
+            CircularProgressIndicator(
+                progress = { percentage },
+                modifier = Modifier.fillMaxSize(),
+                color = colors.green800,
+                strokeWidth = 24.dp,
+                strokeCap = StrokeCap.Round,
+                trackColor = Color.Transparent
+            )
+
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    text = "${(percentage * 100).toInt()}%",
+                    style = typography.head4.copy(fontWeight = FontWeight.Bold),
+                    color = colors.black700
+                )
+                Text(
+                    text = "пройдено",
+                    style = typography.body4,
+                    color = colors.black700
+                )
+            }
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            StatItem("Всего", totalQuestions.toString(), colors, typography)
+            StatItem("Новые", newQuestions.toString(), colors, typography)
+            StatItem("В процессе", inProgress.toString(), colors, typography)
+            StatItem("Изучено", studied.toString(), colors, typography)
+        }
+    }
+}
+
+@Composable
+private fun QuestionItem(
+    question: InterviewQuizResultState.Loaded.VoQuestionResult,
+    colors: Colors,
+    typography: Typography
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 6.dp),
+        shape = RoundedCornerShape(CARD_RADIUS),
+        elevation = CardDefaults.cardElevation(2.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(H_PADDING),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(72.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(Color(0xFF0F1C2E))
+            ) {
+                Image(
+                    painter = painterResource(id = ru.yeahub.ui.R.drawable.question_image),
+                    contentDescription = null,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop
+                )
+            }
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = question.questionText,
+                    style = typography.body3Strong,
+                    color = colors.black900,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Row(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(Color(0xFFF3F3F3))
+                        .padding(horizontal = 12.dp, vertical = 6.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    val isCorrect = question.isCorrect
+
+                    Text(
+                        text = if (isCorrect) "👍" else "👎",
+                        color = if (isCorrect) Color(0xFF6C3CF0) else Color(0xFF9E9E9E),
+                        style = typography.body3
+                    )
+
+                    Spacer(modifier = Modifier.width(6.dp))
+
+                    Text(
+                        text = if (isCorrect) "Знаю" else "Не знаю",
+                        color = if (isCorrect) Color(0xFF6C3CF0) else Color(0xFF9E9E9E),
+                        style = typography.body3
+                    )
+                }
+            }
+        }
+    }
+}
+
+@StaticPreview
+@Composable
+internal fun InterviewQuizResultScreenPreview(
+    @PreviewParameter(InterviewQuizResultStateParamProvider::class)
+    state: InterviewQuizResultState,
+) {
+    ScreenUI(
+        state = rememberUpdatedState(state),
+        onEvent = {},
+        titleTopAppBar = TextOrResource.Resource(R.string.interview_quiz_result_result)
+    )
+}
+
+class InterviewQuizResultStateParamProvider :
+    PreviewParameterProvider<InterviewQuizResultState> {
+
+    override val values = sequenceOf(
+        InterviewQuizResultState.Loaded(
+            overallPercentage = 0.75f,
+            totalQuestions = 20,
+            newQuestions = 50,
+            inProgress = 120,
+            studied = 12,
+            skills = listOf(
+                InterviewQuizResultState.Loaded.VoSkillStat("HTML", 60, 120),
+                InterviewQuizResultState.Loaded.VoSkillStat("CSS", 60, 120),
+                InterviewQuizResultState.Loaded.VoSkillStat("JavaScript", 60, 120),
+                InterviewQuizResultState.Loaded.VoSkillStat("React", 60, 120),
+                InterviewQuizResultState.Loaded.VoSkillStat("PHP", 60, 120),
+                InterviewQuizResultState.Loaded.VoSkillStat("JavaScript", 60, 120)
+            ),
+            questions = listOf(
+                InterviewQuizResultState.Loaded.VoQuestionResult(
+                    "Что такое Virtual DOM, и как он работает?",
+                    false
+                ),
+                InterviewQuizResultState.Loaded.VoQuestionResult(
+                    "Что такое Virtual DOM, и как он работает?",
+                    true
+                ),
+                InterviewQuizResultState.Loaded.VoQuestionResult(
+                    "Что такое Virtual DOM, и как он работает?",
+                    false
+                ),
+                InterviewQuizResultState.Loaded.VoQuestionResult(
+                    "Что такое Virtual DOM, и как он работает?",
+                    true
+                ),
+                InterviewQuizResultState.Loaded.VoQuestionResult(
+                    "Что такое Virtual DOM, и как он работает?",
+                    false
+                )
+            )
+        )
+    )
+}

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/ui/InterviewQuizResultScreen.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/ui/InterviewQuizResultScreen.kt
@@ -68,28 +68,26 @@ private val SKILL_BAR_HEIGHT = 12.dp
 private val SKILL_BAR_SPACING = 12.dp
 
 @Composable
-fun InterviewQuizResultScreen(titleTopAppBarResId: Int) {
+fun InterviewQuizResultScreen() {
     val viewModel: InterviewQuizResultViewModel = koinViewModel()
     val state = viewModel.state.collectAsStateWithLifecycle()
 
     ScreenUI(
         state = state,
-        onEvent = viewModel::onEvent,
-        titleTopAppBar = TextOrResource.Resource(titleTopAppBarResId)
+        onEvent = viewModel::onEvent
     )
 }
 
 @Composable
 private fun ScreenUI(
     state: State<InterviewQuizResultState>,
-    onEvent: (InterviewQuizResultEvent) -> Unit,
-    titleTopAppBar: TextOrResource,
+    onEvent: (InterviewQuizResultEvent) -> Unit
 ) {
     Scaffold(
         containerColor = colors.black10,
         topBar = {
             TopAppBarWithBottomBorder(
-                title = TextOrResource.Resource(R.string.create_quiz_top_bar_header_text),
+                title = state.value.titleTopAppBar,
                 onBackClick = {  }
             )
         }
@@ -467,8 +465,7 @@ internal fun InterviewQuizResultScreenPreview(
 ) {
     ScreenUI(
         state = rememberUpdatedState(state),
-        onEvent = {},
-        titleTopAppBar = TextOrResource.Resource(R.string.interview_quiz_result_result)
+        onEvent = {}
     )
 }
 
@@ -511,7 +508,8 @@ class InterviewQuizResultStateParamProvider :
                     "Что такое Virtual DOM, и как он работает?",
                     false
                 )
-            )
+            ),
+            titleTopAppBar = TextOrResource.Resource(R.string.create_quiz_top_bar_header_text)
         )
     )
 }

--- a/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/ui/InterviewQuizResultScreenLoading.kt
+++ b/feature/interview-trainer/impl/src/main/java/ru/yeahub/interview_trainer/impl/interviewQuizResult/ui/InterviewQuizResultScreenLoading.kt
@@ -1,0 +1,154 @@
+package ru.yeahub.interview_trainer.impl.interviewQuizResult.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.valentinilk.shimmer.shimmer
+import ru.yeahub.core_ui.example.staticPreview.StaticPreview
+
+private const val TITLE_WIDTH_FACTOR = 0.7f
+private const val SKILLS_COUNT = 4
+private const val SUBTITLE_WIDTH_FACTOR = 0.6f
+private const val ANSWERS_COUNT = 6
+private const val ANSWER_MAIN_WEIGHT = 1f
+private const val ANSWER_SECONDARY_WEIGHT = 3f
+private const val CARDS_COUNT = 5
+private val SHIMMER_COLOR = Color.LightGray
+private const val CARD_PLACEHOLDER_COLOR_HEX = 0xFF1E1E2E
+private val CARD_PLACEHOLDER_COLOR = Color(CARD_PLACEHOLDER_COLOR_HEX)
+
+@StaticPreview
+@Composable
+fun InterviewQuizResultLoading() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White)
+            .padding(horizontal = 16.dp)
+    ) {
+        Spacer(Modifier.height(24.dp))
+
+        Box(
+            modifier = Modifier
+                .height(32.dp)
+                .fillMaxWidth(TITLE_WIDTH_FACTOR)
+                .background(SHIMMER_COLOR, RoundedCornerShape(4.dp))
+                .shimmer()
+        )
+
+        Spacer(Modifier.height(16.dp))
+
+        Box(
+            modifier = Modifier
+                .size(200.dp)
+                .align(Alignment.CenterHorizontally)
+                .background(SHIMMER_COLOR, RoundedCornerShape(100.dp))
+                .shimmer()
+        )
+
+        Spacer(Modifier.height(16.dp))
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly
+        ) {
+            repeat(SKILLS_COUNT) {
+                Column {
+                    Box(
+                        Modifier
+                            .size(40.dp, 24.dp)
+                            .background(SHIMMER_COLOR)
+                            .shimmer()
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    Box(
+                        Modifier
+                            .size(60.dp, 16.dp)
+                            .background(SHIMMER_COLOR)
+                            .shimmer()
+                    )
+                }
+            }
+        }
+
+        Spacer(Modifier.height(32.dp))
+
+        Box(
+            Modifier
+                .height(28.dp)
+                .fillMaxWidth(SUBTITLE_WIDTH_FACTOR)
+                .background(SHIMMER_COLOR)
+                .shimmer()
+        )
+
+        Spacer(Modifier.height(12.dp))
+
+        repeat(ANSWERS_COUNT) {
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 6.dp)
+            ) {
+                Box(
+                    Modifier
+                        .weight(ANSWER_MAIN_WEIGHT)
+                        .height(20.dp)
+                        .background(SHIMMER_COLOR)
+                        .shimmer()
+                )
+                Spacer(Modifier.width(12.dp))
+                Box(
+                    Modifier
+                        .weight(ANSWER_SECONDARY_WEIGHT)
+                        .height(12.dp)
+                        .background(SHIMMER_COLOR)
+                        .shimmer()
+                )
+                Spacer(Modifier.width(12.dp))
+                Box(
+                    Modifier
+                        .size(60.dp, 20.dp)
+                        .background(SHIMMER_COLOR)
+                        .shimmer()
+                )
+            }
+        }
+        Spacer(Modifier.height(32.dp))
+        Box(
+            Modifier
+                .height(28.dp)
+                .fillMaxWidth(TITLE_WIDTH_FACTOR)
+                .background(SHIMMER_COLOR)
+                .shimmer()
+        )
+        Spacer(Modifier.height(12.dp))
+        repeat(CARDS_COUNT) {
+            Card(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(72.dp)
+                    .shimmer(),
+                shape = RoundedCornerShape(12.dp),
+                colors = CardDefaults.cardColors(containerColor = CARD_PLACEHOLDER_COLOR)
+            ) {}
+            Spacer(Modifier.height(12.dp))
+        }
+    }
+}

--- a/feature/interview-trainer/impl/src/main/res/values/strings.xml
+++ b/feature/interview-trainer/impl/src/main/res/values/strings.xml
@@ -24,5 +24,10 @@
     <string name="interview_quiz_result_progress">Прогресс обучения по навыкам</string>
     <string name="interview_quiz_result_show_all">Посмотреть статистику</string>
     <string name="interview_quiz_result_questuions">Список пройденных вопросов собеседования</string>
+    <string name="interview_quiz_result_done">пройдено</string>
+    <string name="interview_quiz_result_overall">Всего</string>
+    <string name="interview_quiz_result_new">Новые</string>
+    <string name="interview_quiz_result_in_progress">В процессе</string>
+    <string name="interview_quiz_result_studied">Изучено</string>
 
 </resources>

--- a/feature/interview-trainer/impl/src/main/res/values/strings.xml
+++ b/feature/interview-trainer/impl/src/main/res/values/strings.xml
@@ -19,4 +19,10 @@
     <string name="quiz_btn_complete">Завершить</string>
     <string name="quiz_btn_prev">Назад</string>
     <string name="quiz_btn_next">Далее</string>
+    <string name="interview_quiz_result_result">Результаты</string>
+    <string name="interview_quiz_result_statistics">Статистика пройденных вопросов собеседования</string>
+    <string name="interview_quiz_result_progress">Прогресс обучения по навыкам</string>
+    <string name="interview_quiz_result_show_all">Посмотреть статистику</string>
+    <string name="interview_quiz_result_questuions">Список пройденных вопросов собеседования</string>
+
 </resources>

--- a/feature/interview-trainer/impl/src/main/res/values/strings.xml
+++ b/feature/interview-trainer/impl/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="quiz_btn_prev">Назад</string>
     <string name="quiz_btn_next">Далее</string>
     <string name="interview_quiz_result_result">Результаты</string>
+
     <string name="interview_quiz_result_statistics">Статистика пройденных вопросов собеседования</string>
     <string name="interview_quiz_result_progress">Прогресс обучения по навыкам</string>
     <string name="interview_quiz_result_show_all">Посмотреть статистику</string>


### PR DESCRIPTION
Что сделано:

Полная верстка экрана, добавлены стейты, event, экран во время загрузки, маппер.

Дизайн отличается в малых деталях, так как, допустим, если брать диаграмму то при ее загруженности в 75% как в фигме результат не совпадает с ожидаемым, такой процент загруженности совпадает с 60%

Также далее поправлю некоторые отступы и картинку у верных/неверных ответов.


<img width="368" height="827" alt="image" src="https://github.com/user-attachments/assets/f65a8782-9741-41e1-a47e-6da01681b9ed" />

<img width="383" height="763" alt="image" src="https://github.com/user-attachments/assets/763003d9-bb8e-4fcb-8817-f1f7cc53fda1" />

<img width="320" height="693" alt="image" src="https://github.com/user-attachments/assets/773943db-2056-4cc9-bded-23a366667667" />

<img width="467" height="797" alt="image" src="https://github.com/user-attachments/assets/470dd6fc-f73a-4f3d-939a-623dccd50c4e" />







